### PR TITLE
Add "use any exotic" option

### DIFF
--- a/src/app/components/authenticated-v2/settings/desired-exotic-selection/desired-exotic-selection.component.html
+++ b/src/app/components/authenticated-v2/settings/desired-exotic-selection/desired-exotic-selection.component.html
@@ -1,10 +1,20 @@
 <span><b>For the FotL mask, scroll down to the "Advanced Settings".</b></span>
 
+<div>
+    <span class="container">
+        <img class="exoticIcon {{ selectedExotics.indexOf(-1) > -1 ? 'selected' : '' }}" 
+        src="https://www.bungie.net/common/destiny2_content/icons/b4d05ef69d0c3227a7d4f7f35bbc2848.png"
+        matTooltip="Force to use NO exotic at all" #tooltip="matTooltip"
+        (click)="selectExotic(-1, $event)">
+    </span>
+    <span class="container">
+        <img class="exoticIcon {{ selectedExotics.indexOf(-2) > -1 ? 'selected' : '' }}" 
+       src="https://bungie.net/common/destiny2_content/icons/ee21b5bc72f9e48366c9addff163a187.png"
+       matTooltip="Force to guarantee use of an exotic" #tooltip="matTooltip"
+       (click)="selectExotic(-2, $event)">
+    </span>
+</div>
 <div *ngFor="let itemGroup of exotics; let i = index" [@listAnimation]="itemGroup.length">
-  <img class="exoticIcon {{ selectedExotics.indexOf(-1) > -1 ? 'selected' : '' }}" *ngIf="i == 0"
-       src="https://www.bungie.net/common/destiny2_content/icons/b4d05ef69d0c3227a7d4f7f35bbc2848.png"
-       matTooltip="Force to use NO exotic at all" #tooltip="matTooltip"
-       (click)="selectExotic(-1, $event)">
   <span class="container" *ngFor="let exotic of itemGroup">
     <img class="exoticIcon {{selectedExotics.indexOf(exotic.item.hash) > -1 ? 'selected' : ''}}"
          src="https://www.bungie.net/{{exotic.item.icon}}"

--- a/src/app/components/authenticated-v2/settings/desired-exotic-selection/desired-exotic-selection.component.ts
+++ b/src/app/components/authenticated-v2/settings/desired-exotic-selection/desired-exotic-selection.component.ts
@@ -5,7 +5,7 @@ import {CharacterClass} from "../../../../data/enum/character-Class";
 import {animate, query, stagger, style, transition, trigger} from "@angular/animations";
 import {IManifestArmor} from "../../../../data/types/IManifestArmor";
 import {ArmorSlot} from "../../../../data/enum/armor-slot";
-import {FORCE_USE_NO_EXOTIC} from "../../../../data/constants";
+import {FORCE_USE_NO_EXOTIC, FORCE_USE_ANY_EXOTIC} from "../../../../data/constants";
 import {debounceTime, takeUntil} from "rxjs/operators";
 import {Subject} from "rxjs";
 
@@ -89,6 +89,8 @@ export class DesiredExoticSelectionComponent implements OnInit, OnDestroy {
       this.selectedExotics.splice(index, 1)
     } else if (hash == FORCE_USE_NO_EXOTIC) {
       this.selectedExotics = [FORCE_USE_NO_EXOTIC]
+    } else if (hash == FORCE_USE_ANY_EXOTIC) {
+        this.selectedExotics = [FORCE_USE_ANY_EXOTIC]
     } else if (this.selectedExotics.length == 0 || !$event.shiftKey) {
       // if length is 0 or shift is NOT pressed, add the exotic
       this.selectedExotics = [hash]

--- a/src/app/data/constants.ts
+++ b/src/app/data/constants.ts
@@ -3,4 +3,4 @@ export const MINIMUM_STAT_MOD_AMOUNT = 0;
 
 
 export const FORCE_USE_NO_EXOTIC = -1;
-
+export const FORCE_USE_ANY_EXOTIC = -2;

--- a/src/app/services/results-builder.worker.ts
+++ b/src/app/services/results-builder.worker.ts
@@ -2,7 +2,7 @@ import {BuildConfiguration} from "../data/buildConfiguration";
 import {IInventoryArmor} from "../data/types/IInventoryArmor";
 import {buildDb} from "../data/database";
 import {ArmorSlot} from "../data/enum/armor-slot";
-import {FORCE_USE_NO_EXOTIC} from "../data/constants";
+import {FORCE_USE_ANY_EXOTIC, FORCE_USE_NO_EXOTIC} from "../data/constants";
 import {ModInformation} from "../data/ModInformation";
 import {ArmorPerkOrSlot, ArmorStat, SpecialArmorStat, STAT_MOD_VALUES, StatModifier} from "../data/enum/armor-stat";
 import {IManifestArmor} from "../data/types/IManifestArmor";
@@ -1014,7 +1014,11 @@ function handlePermutation(
     return null;
 
   const exotic = helmet.containsExotics ? helmet : gauntlet.containsExotics ? gauntlet : chest.containsExotics ? chest : leg.containsExotics ? leg : null
-  return {
+  if (!exotic && config.selectedExotics.indexOf(FORCE_USE_ANY_EXOTIC) != -1) {
+    return null;
+  }
+  
+  return { 
     exotic: exotic == null ? [] : [{
       icon: exotic?.items[0].icon,
       watermark: exotic?.items[0].watermarkIcon,


### PR DESCRIPTION
Add an option that allows a user to select "use any exotic," forces the engine to ignore loadouts that do not include an exotic. 

With the addition of a second "special" exotic button, moved the two selection options to above the other armor pieces, seemed to add some clarity to the armor type lists

With no special option selected:
<img width="733" alt="image" src="https://user-images.githubusercontent.com/55564683/215599797-fad7dd5b-6156-4bb1-a8ab-a1f643566979.png">

With "Force no exotic" selected:
<img width="751" alt="image" src="https://user-images.githubusercontent.com/55564683/215599888-1ed68c8f-029b-44be-a045-e2a2b42becb6.png">

With "Use any exotic" selected: 
<img width="749" alt="image" src="https://user-images.githubusercontent.com/55564683/215599954-a12c13bc-a764-401f-8f21-5fe98b2961c6.png">

No exotic \# + Any exotic \# == no selections \# (woohoo!)
