### PR TITLE
Collection and Vendor sources

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -95,6 +95,10 @@ import { StatCooldownTooltipDirective } from "./components/authenticated-v2/over
 import { SlotLimitationTitleComponent } from "./components/authenticated-v2/settings/desired-mod-limit-selection/slot-limitation-title/slot-limitation-title.component";
 import { CommonMaterialModule } from "./modules/common-material/common-material.module";
 import { CommonModule } from "@angular/common";
+import {
+  VendorIdFromItemIdPipe,
+  VendorNamePipe,
+} from "./components/authenticated-v2/pipes/vendor-name-pipe";
 
 const routes: Routes = [
   {
@@ -159,6 +163,8 @@ const routes: Routes = [
     ConfirmDialogComponent,
     ExpandedResultContentComponent,
     CountElementInListPipe,
+    VendorIdFromItemIdPipe,
+    VendorNamePipe,
     IgnoredItemsListComponent,
     HelpPageComponent,
     ArmorPickerPageComponent,

--- a/src/app/components/authenticated-v2/components/item-icon/item-icon.component.html
+++ b/src/app/components/authenticated-v2/components/item-icon/item-icon.component.html
@@ -26,5 +26,10 @@
     class="item-icon-overlay"
     src="https://bungie.net/{{ item.watermarkIcon }}"
     *ngIf="item.watermarkIcon" />
+  <div
+    class="item-source-overlay"
+    *ngIf="isFromVendor || isFromCollection"
+    [class.vendor-item]="isFromVendor"
+    [class.collection-item]="isFromCollection"></div>
   <div *ngIf="masterworked" class="item-icon-masterwork-overlay"></div>
 </div>

--- a/src/app/components/authenticated-v2/components/item-icon/item-icon.component.scss
+++ b/src/app/components/authenticated-v2/components/item-icon/item-icon.component.scss
@@ -40,6 +40,7 @@
   position: relative;
   transition: opacity 0.2s, transform 0.2s;
   width: 100%;
+  --icon-size: 22px;
 }
 
 .item-icon-overlay,
@@ -50,3 +51,5 @@
   width: 100%;
   pointer-events: none;
 }
+
+@import "./item-source-overlay";

--- a/src/app/components/authenticated-v2/components/item-icon/item-icon.component.ts
+++ b/src/app/components/authenticated-v2/components/item-icon/item-icon.component.ts
@@ -18,6 +18,7 @@
 import { AfterViewInit, Component, Input, OnInit } from "@angular/core";
 import { IManifestArmor } from "../../../../data/types/IManifestArmor";
 import { ItemIconServiceService } from "../../../../services/item-icon-service.service";
+import { InventoryArmorSource } from "src/app/data/types/IInventoryArmor";
 
 @Component({
   selector: "app-item-icon",
@@ -30,11 +31,19 @@ export class ItemIconComponent implements AfterViewInit {
 
   @Input()
   masterworked: boolean = false;
+
+  @Input()
+  source: InventoryArmorSource = InventoryArmorSource.Inventory;
+  isFromVendor: boolean = false;
+  isFromCollection: boolean = false;
+
   item: IManifestArmor | undefined = undefined;
 
   constructor(private iconService: ItemIconServiceService) {}
 
   async ngAfterViewInit() {
     this.item = await this.iconService.getItemCached(this.itemHash);
+    this.isFromVendor = this.source === InventoryArmorSource.Vendor;
+    this.isFromCollection = this.source === InventoryArmorSource.Collections;
   }
 }

--- a/src/app/components/authenticated-v2/components/item-icon/item-source-overlay.scss
+++ b/src/app/components/authenticated-v2/components/item-icon/item-source-overlay.scss
@@ -1,0 +1,17 @@
+.item-source-overlay {
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 0;
+  pointer-events: none;
+
+  border-top: calc(var(--icon-size) / 2) solid transparent;
+  border-right: calc(var(--icon-size) / 2) solid transparent;
+
+  &.vendor-item {
+    border-top-color: blue;
+  }
+  &.collection-item {
+    border-top-color: lightgreen;
+  }
+}

--- a/src/app/components/authenticated-v2/overlays/armor-tooltip-component/armor-tooltip.component.html
+++ b/src/app/components/authenticated-v2/overlays/armor-tooltip-component/armor-tooltip.component.html
@@ -22,6 +22,10 @@
         <td colspan="3">{{ itemTooltip?.name }}</td>
       </tr>
       <tr>
+        <td>Source</td>
+        <td>{{ getSourceText() }}</td>
+      </tr>
+      <tr>
         <td>Current stats:</td>
       </tr>
       <tr *ngFor="let stat of itemTooltip?.stats; let i = index">

--- a/src/app/components/authenticated-v2/overlays/armor-tooltip-component/armor-tooltip.component.html
+++ b/src/app/components/authenticated-v2/overlays/armor-tooltip-component/armor-tooltip.component.html
@@ -23,7 +23,13 @@
       </tr>
       <tr>
         <td>Source</td>
-        <td>{{ getSourceText() }}</td>
+        <td colspan="2">{{ getSourceText() }}</td>
+      </tr>
+      <tr *ngIf="isVendorItem && itemTooltip">
+        <td>Vendor</td>
+        <td colspan="2">{{
+          itemTooltip.itemInstanceId | getVendorIdFromItemId | getVendorName | async
+        }}</td>
       </tr>
       <tr>
         <td>Current stats:</td>
@@ -44,6 +50,12 @@
               >&nbsp;</div
             >
           </div>
+        </td>
+      </tr>
+      <tr>
+        <td>Total base stats:</td>
+        <td>
+          {{ getTotalStats() }}
         </td>
       </tr>
     </table>

--- a/src/app/components/authenticated-v2/overlays/armor-tooltip-component/armor-tooltip.component.ts
+++ b/src/app/components/authenticated-v2/overlays/armor-tooltip-component/armor-tooltip.component.ts
@@ -18,7 +18,7 @@
 import { Component, Input, OnInit, TemplateRef } from "@angular/core";
 import { ResultItem } from "../../results/results.component";
 import { ArmorStat, ArmorStatNames } from "../../../../data/enum/armor-stat";
-import { InventoryArmorSource } from "src/app/data/types/IInventoryArmor";
+import { InventoryArmorSourceNames } from "src/app/data/enum/armor-source";
 
 @Component({
   selector: "app-armor-tooltip-component",
@@ -29,16 +29,11 @@ export class ArmorTooltipComponent {
   @Input() itemTooltip: ResultItem | undefined;
 
   getSourceText() {
-    switch (this.itemTooltip?.source) {
-      case InventoryArmorSource.Collections:
-        return "Collections";
-
-      case InventoryArmorSource.Vendor:
-        return "Vendor";
-
-      default:
-        return "Inventory";
+    if (!this.itemTooltip) {
+      return "";
     }
+
+    return InventoryArmorSourceNames[this.itemTooltip.source];
   }
 
   getArmorStatName(i: number) {

--- a/src/app/components/authenticated-v2/overlays/armor-tooltip-component/armor-tooltip.component.ts
+++ b/src/app/components/authenticated-v2/overlays/armor-tooltip-component/armor-tooltip.component.ts
@@ -19,6 +19,7 @@ import { Component, Input, OnInit, TemplateRef } from "@angular/core";
 import { ResultItem } from "../../results/results.component";
 import { ArmorStat, ArmorStatNames } from "../../../../data/enum/armor-stat";
 import { InventoryArmorSourceNames } from "src/app/data/enum/armor-source";
+import { InventoryArmorSource } from "src/app/data/types/IInventoryArmor";
 
 @Component({
   selector: "app-armor-tooltip-component",
@@ -44,5 +45,12 @@ export class ArmorTooltipComponent {
     return Math.min(100, (stat / 32) * 100) + "%";
   }
 
+  getTotalStats() {
+    return this.itemTooltip?.stats.reduce((a, b) => a + b, 0) || 0;
+  }
+
+  get isVendorItem() {
+    return this.itemTooltip?.source === InventoryArmorSource.Vendor;
+  }
   constructor() {}
 }

--- a/src/app/components/authenticated-v2/overlays/armor-tooltip-component/armor-tooltip.component.ts
+++ b/src/app/components/authenticated-v2/overlays/armor-tooltip-component/armor-tooltip.component.ts
@@ -33,6 +33,9 @@ export class ArmorTooltipComponent {
       case InventoryArmorSource.Collections:
         return "Collections";
 
+      case InventoryArmorSource.Vendor:
+        return "Vendor";
+
       default:
         return "Inventory";
     }

--- a/src/app/components/authenticated-v2/overlays/armor-tooltip-component/armor-tooltip.component.ts
+++ b/src/app/components/authenticated-v2/overlays/armor-tooltip-component/armor-tooltip.component.ts
@@ -18,6 +18,7 @@
 import { Component, Input, OnInit, TemplateRef } from "@angular/core";
 import { ResultItem } from "../../results/results.component";
 import { ArmorStat, ArmorStatNames } from "../../../../data/enum/armor-stat";
+import { InventoryArmorSource } from "src/app/data/types/IInventoryArmor";
 
 @Component({
   selector: "app-armor-tooltip-component",
@@ -26,6 +27,16 @@ import { ArmorStat, ArmorStatNames } from "../../../../data/enum/armor-stat";
 })
 export class ArmorTooltipComponent {
   @Input() itemTooltip: ResultItem | undefined;
+
+  getSourceText() {
+    switch (this.itemTooltip?.source) {
+      case InventoryArmorSource.Collections:
+        return "Collections";
+
+      default:
+        return "Inventory";
+    }
+  }
 
   getArmorStatName(i: number) {
     return ArmorStatNames[i as ArmorStat];

--- a/src/app/components/authenticated-v2/overlays/exotic-perk-tooltip/exotic-perk-tooltip.component.css
+++ b/src/app/components/authenticated-v2/overlays/exotic-perk-tooltip/exotic-perk-tooltip.component.css
@@ -36,3 +36,10 @@
 .exotic-name {
   color: #eedb9e;
 }
+
+
+.collection-roll-info {
+  color: #5cc3ec;
+  font-size: 12px;
+  margin-top: 5px;
+}

--- a/src/app/components/authenticated-v2/overlays/exotic-perk-tooltip/exotic-perk-tooltip.component.html
+++ b/src/app/components/authenticated-v2/overlays/exotic-perk-tooltip/exotic-perk-tooltip.component.html
@@ -44,6 +44,18 @@
           {{ exoticPerk.description }}
         </td>
       </tr>
+
+      <tr *ngIf="collection || vendor" class="collection-roll-info">
+        <td colspan="2">
+          This exotic is not in your inventory but it is
+          <ng-container *ngIf="collection">
+            in your collection
+            <ng-container *ngIf="vendor"> and </ng-container>
+          </ng-container>
+          <ng-container *ngIf="vendor">available at a vendor</ng-container>. You can still generate
+          a loadout with this exotic, but you will have to grab it by yourself.
+        </td>
+      </tr>
     </table>
   </div>
 </div>

--- a/src/app/components/authenticated-v2/overlays/exotic-perk-tooltip/exotic-perk-tooltip.component.ts
+++ b/src/app/components/authenticated-v2/overlays/exotic-perk-tooltip/exotic-perk-tooltip.component.ts
@@ -29,6 +29,9 @@ import { ItemIconServiceService } from "../../../../services/item-icon-service.s
 })
 export class ExoticPerkTooltipComponent implements OnInit {
   @Input() armor: IManifestArmor | undefined;
+  @Input() vendor: boolean = false;
+  @Input() collection: boolean = false;
+
   exoticPerk: IManifestArmor | undefined;
   exoticPerkNotThere: boolean = false;
 

--- a/src/app/components/authenticated-v2/overlays/exotic-perk-tooltip/exotic-tooltip.directive.ts
+++ b/src/app/components/authenticated-v2/overlays/exotic-perk-tooltip/exotic-tooltip.directive.ts
@@ -43,6 +43,10 @@ export class ExoticTooltipDirective implements OnInit, OnDestroy {
   //If this is specified then specified text will be show in in the tooltip
   @Input() exoticTooltip: IManifestArmor | undefined;
 
+  @Input() exoticTooltipInVendor: boolean = false;
+
+  @Input() exoticTooltipInCollection: boolean = false;
+
   //If this is specified then specified template will be rendered in the tooltip
   @Input() contentTemplate: TemplateRef<any> | undefined;
 
@@ -97,6 +101,8 @@ export class ExoticTooltipDirective implements OnInit, OnDestroy {
       const tooltipRef: ComponentRef<ExoticPerkTooltipComponent> = this._overlayRef.attach(
         new ComponentPortal(ExoticPerkTooltipComponent)
       );
+      tooltipRef.instance.collection = this.exoticTooltipInCollection;
+      tooltipRef.instance.vendor = this.exoticTooltipInVendor;
       tooltipRef.instance.armor = this.exoticTooltip;
     }
   }

--- a/src/app/components/authenticated-v2/pipes/vendor-name-pipe.ts
+++ b/src/app/components/authenticated-v2/pipes/vendor-name-pipe.ts
@@ -1,0 +1,30 @@
+import { Pipe, PipeTransform } from "@angular/core";
+import { DatabaseService } from "src/app/services/database.service";
+
+@Pipe({
+  name: "getVendorName",
+  pure: true,
+})
+export class VendorNamePipe implements PipeTransform {
+  constructor(private database: DatabaseService) {}
+
+  async transform(value: number): Promise<string> {
+    const vendor = await this.database.vendorNames.where("vendorId").equals(value).first();
+    return vendor?.vendorName ?? "Unknown Vendor";
+  }
+}
+
+@Pipe({
+  name: "getVendorIdFromItemId",
+  pure: true,
+})
+export class VendorIdFromItemIdPipe implements PipeTransform {
+  constructor() {}
+
+  transform(value: string): number {
+    if (!value || !value.startsWith("v")) return -1;
+    const vendorId = parseInt(value.substring(1).split("-")[0]);
+    if (isNaN(vendorId)) return -1;
+    return vendorId;
+  }
+}

--- a/src/app/components/authenticated-v2/results/expanded-result-content/expanded-result-content.component.html
+++ b/src/app/components/authenticated-v2/results/expanded-result-content/expanded-result-content.component.html
@@ -94,7 +94,9 @@
             <app-item-icon
               [itemHash]="i.hash"
               [masterworked]="i.masterworked"
-              class="item-icon"></app-item-icon>
+              [source]="i.source"
+              class="item-icon">
+            </app-item-icon>
           </div>
         </td>
         <td class="icon-column">

--- a/src/app/components/authenticated-v2/results/expanded-result-content/expanded-result-content.component.ts
+++ b/src/app/components/authenticated-v2/results/expanded-result-content/expanded-result-content.component.ts
@@ -54,6 +54,7 @@ import {
   UpgradeSpendTier,
 } from "@destinyitemmanager/dim-api-types";
 import { CharacterClass } from "src/app/data/enum/character-Class";
+import { MembershipService } from "src/app/services/membership.service";
 
 @Component({
   selector: "app-expanded-result-content",
@@ -82,7 +83,8 @@ export class ExpandedResultContentComponent implements OnInit, OnDestroy {
   constructor(
     private config: ConfigurationService,
     private _snackBar: MatSnackBar,
-    private bungieApi: BungieApiService
+    private bungieApi: BungieApiService,
+    private membership: MembershipService
   ) {}
 
   public buildItemIdString(element: ResultDefinition | null) {
@@ -156,7 +158,7 @@ export class ExpandedResultContentComponent implements OnInit, OnDestroy {
 
   async getCharacterId() {
     // get character Id
-    let characters = await this.bungieApi.getCharacters();
+    let characters = await this.membership.getCharacters();
     characters = characters.filter((c) => c.clazz == this.config_characterClass);
     if (characters.length == 0) {
       this.openSnackBar("Error: Could not find a character to move the items to.");

--- a/src/app/components/authenticated-v2/results/results.component.html
+++ b/src/app/components/authenticated-v2/results/results.component.html
@@ -163,6 +163,20 @@
             matTooltip="Some masterwork assumptions are in place. This means that you may have to masterwork items. Look at your advanced settings to see which ones are activated.">
             Masterwork Assumption
           </mat-chip>
+          <mat-chip
+            #tooltip="matTooltip"
+            *ngIf="_config_includeCollectionRolls"
+            disableRipple
+            matTooltip="Collection Exotic rolls will be included in the search.">
+            Include Collection Rolls
+          </mat-chip>
+          <mat-chip
+            #tooltip="matTooltip"
+            *ngIf="_config_includeVendorRolls"
+            disableRipple
+            matTooltip="Currently available Vendor items will be included in the search.">
+            Include Vendor Items
+          </mat-chip>
         </mat-chip-list>
       </mat-form-field>
 

--- a/src/app/components/authenticated-v2/results/results.component.html
+++ b/src/app/components/authenticated-v2/results/results.component.html
@@ -339,6 +339,26 @@
               src="https://www.bungie.net/common/destiny2_content/icons/b4d05ef69d0c3227a7d4f7f35bbc2848.png" />
           </td>
         </ng-container>
+
+        <!-- Vendor/Collection Column -->
+        <ng-container matColumnDef="source">
+          <th *matHeaderCellDef mat-header-cell>Sources</th>
+          <td *matCellDef="let element" mat-cell>
+            <span class="source-column">
+              <img
+                *ngIf="!!element.usesCollectionRoll"
+                matTooltip="This build uses a collection exotic. You have to collect it before you can use it."
+                class="collectionIcon"
+                src="https://www.bungie.net/common/destiny2_content/icons/1d01287dd47af97fef16fa6acbac23ba.png" />
+              <img
+                *ngIf="!!element.usesVendorRoll"
+                matTooltip="This build uses a vendor item. You have to collect it before you can use it."
+                class="vendorIcon"
+                src="https://www.bungie.net/common/destiny2_content/icons/8ef4b5bd32277dba9aee7c368404ad5d.jpg" />
+            </span>
+          </td>
+        </ng-container>
+
         <!-- Name Column -->
         <ng-container matColumnDef="dropdown">
           <th *matHeaderCellDef mat-header-cell></th>

--- a/src/app/components/authenticated-v2/results/results.component.scss
+++ b/src/app/components/authenticated-v2/results/results.component.scss
@@ -48,6 +48,22 @@
   pointer-events: none;
 }
 
+.source-column {
+  float: left;
+
+  img:nth-of-type(2) {
+    margin-top: 5px;
+    margin-bottom: -3px;
+  }
+}
+
+.collectionIcon,
+.vendorIcon {
+  width: 32px;
+  margin-left: 3px;
+  display: block;
+}
+
 tr.example-element-row td {
   border-bottom-width: 0;
 }

--- a/src/app/components/authenticated-v2/results/results.component.ts
+++ b/src/app/components/authenticated-v2/results/results.component.ts
@@ -35,6 +35,7 @@ import { ArmorSlot } from "../../../data/enum/armor-slot";
 import { FixableSelection } from "../../../data/buildConfiguration";
 import { Subject } from "rxjs";
 import { takeUntil } from "rxjs/operators";
+import { InventoryArmorSource } from "src/app/data/types/IInventoryArmor";
 
 export interface ResultDefinition {
   exotic:
@@ -83,7 +84,7 @@ export interface ResultItem {
   perk: ArmorPerkOrSlot;
   transferState: ResultItemMoveState;
   statsNoMods: number[];
-  source: number;
+  source: InventoryArmorSource;
 }
 
 @Component({

--- a/src/app/components/authenticated-v2/results/results.component.ts
+++ b/src/app/components/authenticated-v2/results/results.component.ts
@@ -83,6 +83,7 @@ export interface ResultItem {
   perk: ArmorPerkOrSlot;
   transferState: ResultItemMoveState;
   statsNoMods: number[];
+  source: number;
 }
 
 @Component({

--- a/src/app/components/authenticated-v2/results/results.component.ts
+++ b/src/app/components/authenticated-v2/results/results.component.ts
@@ -115,6 +115,8 @@ export class ResultsComponent implements OnInit, OnDestroy {
   _config_selectedExotics: number[] = [];
   _config_tryLimitWastedStats: boolean = false;
   _config_onlyUseMasterworkedItems: Boolean = false;
+  _config_includeCollectionRolls: Boolean = false;
+  _config_includeVendorRolls: Boolean = false;
   _config_onlyShowResultsWithNoWastedStats: Boolean = false;
   _config_assumeEveryLegendaryIsArtifice: Boolean = false;
   _config_modslotLimitation: FixableSelection<number>[] = [];
@@ -164,6 +166,8 @@ export class ResultsComponent implements OnInit, OnDestroy {
 
       this._config_maximumStatMods = c.maximumStatMods;
       this._config_onlyUseMasterworkedItems = c.onlyUseMasterworkedItems;
+      this._config_includeCollectionRolls = c.includeCollectionRolls;
+      this._config_includeVendorRolls = c.includeVendorRolls;
       this._config_onlyShowResultsWithNoWastedStats = c.onlyShowResultsWithNoWastedStats;
       this._config_assumeEveryLegendaryIsArtifice = c.assumeEveryLegendaryIsArtifice;
       this._config_selectedExotics = c.selectedExotics;

--- a/src/app/components/authenticated-v2/results/results.component.ts
+++ b/src/app/components/authenticated-v2/results/results.component.ts
@@ -60,6 +60,8 @@ export interface ResultDefinition {
   modCost: number;
   modCount: number;
   loaded: boolean;
+  usesCollectionRoll?: boolean;
+  usesVendorRoll?: boolean;
 }
 
 export enum ResultItemMoveState {
@@ -190,6 +192,7 @@ export class ResultsComponent implements OnInit, OnDestroy {
         "mods",
       ];
       if (c.showWastedStatsColumn) columns.push("waste");
+      if (c.includeVendorRolls || c.includeCollectionRolls) columns.push("source");
       columns.push("dropdown");
       this.shownColumns = columns;
     });

--- a/src/app/components/authenticated-v2/settings/advanced-settings/advanced-settings.component.ts
+++ b/src/app/components/authenticated-v2/settings/advanced-settings/advanced-settings.component.ts
@@ -72,6 +72,14 @@ export class AdvancedSettingsComponent implements OnInit, OnDestroy {
             impactsResultCount: false,
             help: "Ignore sunset armor in the results.",
           },
+          {
+            name: "Include vendor items.",
+            cp: (v: boolean) => this.config.modifyConfiguration((c) => (c.includeVendorRolls = v)),
+            value: c.includeVendorRolls,
+            disabled: false,
+            impactsResultCount: false,
+            help: "Include armor pieces that can currently be bought from a vendor.",
+          },
         ],
         Masterwork: [
           {

--- a/src/app/components/authenticated-v2/settings/desired-exotic-selection/desired-exotic-selection.component.html
+++ b/src/app/components/authenticated-v2/settings/desired-exotic-selection/desired-exotic-selection.component.html
@@ -37,11 +37,23 @@
       class="exoticIcon {{ selectedExotics.indexOf(exotic.item.hash) > -1 ? 'selected' : '' }}"
       src="https://www.bungie.net/{{ exotic.item.icon }}"
       [exoticTooltip]="exotic.item"
-      [class.disabled]="!exotic.inInventory"
-      (click)="exotic.inInventory && selectExotic(exotic.item.hash, $event)" />
+      [class.disabled]="includeCollectionRolls ? !exotic.inCollection : !exotic.inInventory"
+      (click)="
+        (exotic.inInventory || (includeCollectionRolls && exotic.inCollection)) &&
+          selectExotic(exotic.item.hash, $event)
+      " />
     <img
       class="watermarkIcon"
       *ngIf="exotic.item.watermarkIcon"
       src="https://www.bungie.net/{{ exotic.item.watermarkIcon }}" />
   </span>
+</div>
+
+<div>
+  <mat-slide-toggle
+    color="primary"
+    [checked]="includeCollectionRolls"
+    (change)="setAllowCollectionRolls($event.checked)">
+    Include collection rolls
+  </mat-slide-toggle>
 </div>

--- a/src/app/components/authenticated-v2/settings/desired-exotic-selection/desired-exotic-selection.component.html
+++ b/src/app/components/authenticated-v2/settings/desired-exotic-selection/desired-exotic-selection.component.html
@@ -37,7 +37,13 @@
       class="exoticIcon {{ selectedExotics.indexOf(exotic.item.hash) > -1 ? 'selected' : '' }}"
       src="https://www.bungie.net/{{ exotic.item.icon }}"
       [exoticTooltip]="exotic.item"
-      [class.disabled]="includeCollectionRolls ? !exotic.inCollection : !exotic.inInventory"
+      [class.disabled]="
+        !(
+          exotic.inInventory ||
+          (includeCollectionRolls && exotic.inCollection) ||
+          (includeVendorRolls && exotic.inVendor)
+        )
+      "
       (click)="
         (exotic.inInventory || (includeCollectionRolls && exotic.inCollection)) &&
           selectExotic(exotic.item.hash, $event)

--- a/src/app/components/authenticated-v2/settings/desired-exotic-selection/desired-exotic-selection.component.html
+++ b/src/app/components/authenticated-v2/settings/desired-exotic-selection/desired-exotic-selection.component.html
@@ -37,6 +37,12 @@
       class="exoticIcon {{ selectedExotics.indexOf(exotic.item.hash) > -1 ? 'selected' : '' }}"
       src="https://www.bungie.net/{{ exotic.item.icon }}"
       [exoticTooltip]="exotic.item"
+      [exoticTooltipInVendor]="!exotic.inInventory && includeVendorRolls && exotic.inVendor"
+      [exoticTooltipInCollection]="
+        !exotic.inInventory && includeCollectionRolls && exotic.inCollection
+      "
+      [class.vendor-item]="!exotic.inInventory && includeVendorRolls && exotic.inVendor"
+      [class.collection-item]="!exotic.inInventory && includeCollectionRolls && exotic.inCollection"
       [class.disabled]="
         !(
           exotic.inInventory ||

--- a/src/app/components/authenticated-v2/settings/desired-exotic-selection/desired-exotic-selection.component.html
+++ b/src/app/components/authenticated-v2/settings/desired-exotic-selection/desired-exotic-selection.component.html
@@ -58,6 +58,11 @@
       class="watermarkIcon"
       *ngIf="exotic.item.watermarkIcon"
       src="https://www.bungie.net/{{ exotic.item.watermarkIcon }}" />
+    <div
+      class="item-source-overlay"
+      *ngIf="!exotic.inInventory"
+      [class.vendor-item]="includeVendorRolls && exotic.inVendor"
+      [class.collection-item]="includeCollectionRolls && exotic.inCollection"></div>
   </span>
 </div>
 

--- a/src/app/components/authenticated-v2/settings/desired-exotic-selection/desired-exotic-selection.component.scss
+++ b/src/app/components/authenticated-v2/settings/desired-exotic-selection/desired-exotic-selection.component.scss
@@ -62,3 +62,12 @@
     cursor: default;
   }
 }
+
+.vendor-item {
+  /* rotate color */
+  filter: hue-rotate(130deg);
+}
+
+.collection-item {
+  filter: hue-rotate(180deg);
+}

--- a/src/app/components/authenticated-v2/settings/desired-exotic-selection/desired-exotic-selection.component.scss
+++ b/src/app/components/authenticated-v2/settings/desired-exotic-selection/desired-exotic-selection.component.scss
@@ -15,6 +15,13 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+.container {
+  display: inline-block;
+  position: relative;
+
+  --icon-size: 36px;
+}
+
 .exoticIcon {
   width: 36px;
   height: 36px;
@@ -63,11 +70,8 @@
   }
 }
 
-.vendor-item {
-  /* rotate color */
-  filter: hue-rotate(130deg);
+.item-source-overlay {
+  margin: 2px;
 }
 
-.collection-item {
-  filter: hue-rotate(180deg);
-}
+@import "../../components/item-icon/item-source-overlay.scss";

--- a/src/app/components/authenticated-v2/settings/desired-exotic-selection/desired-exotic-selection.component.ts
+++ b/src/app/components/authenticated-v2/settings/desired-exotic-selection/desired-exotic-selection.component.ts
@@ -45,6 +45,7 @@ export const listAnimation = trigger("listAnimation", [
 export class DesiredExoticSelectionComponent implements OnInit, OnDestroy {
   selectedExotics: number[] = [];
   includeCollectionRolls = false;
+  includeVendorRolls = false;
   currentClass: CharacterClass = CharacterClass.Titan;
   exotics: ClassExoticInfo[][] = [];
 
@@ -57,6 +58,7 @@ export class DesiredExoticSelectionComponent implements OnInit, OnDestroy {
         await this.updateExoticsForClass();
       }
       this.includeCollectionRolls = c.includeCollectionRolls;
+      this.includeVendorRolls = c.includeVendorRolls;
       this.selectedExotics = c.selectedExotics;
     });
 

--- a/src/app/components/authenticated-v2/settings/desired-exotic-selection/desired-exotic-selection.component.ts
+++ b/src/app/components/authenticated-v2/settings/desired-exotic-selection/desired-exotic-selection.component.ts
@@ -16,7 +16,7 @@
  */
 
 import { Component, OnDestroy, OnInit } from "@angular/core";
-import { InventoryService } from "../../../../services/inventory.service";
+import { ClassExoticInfo, InventoryService } from "../../../../services/inventory.service";
 import { ConfigurationService } from "../../../../services/configuration.service";
 import { CharacterClass } from "../../../../data/enum/character-Class";
 import { animate, query, stagger, style, transition, trigger } from "@angular/animations";
@@ -44,8 +44,9 @@ export const listAnimation = trigger("listAnimation", [
 })
 export class DesiredExoticSelectionComponent implements OnInit, OnDestroy {
   selectedExotics: number[] = [];
+  includeCollectionRolls = false;
   currentClass: CharacterClass = CharacterClass.Titan;
-  exotics: { inInventory: boolean; item: IManifestArmor }[][] = [];
+  exotics: ClassExoticInfo[][] = [];
 
   constructor(public inventory: InventoryService, public config: ConfigurationService) {}
 
@@ -55,6 +56,7 @@ export class DesiredExoticSelectionComponent implements OnInit, OnDestroy {
         this.currentClass = c.characterClass;
         await this.updateExoticsForClass();
       }
+      this.includeCollectionRolls = c.includeCollectionRolls;
       this.selectedExotics = c.selectedExotics;
     });
 
@@ -73,7 +75,7 @@ export class DesiredExoticSelectionComponent implements OnInit, OnDestroy {
   private async updateExoticsForClass() {
     const armors = await this.inventory.getExoticsForClass(this.currentClass);
 
-    function uniq(a: { inInventory: boolean; item: IManifestArmor }[]) {
+    function uniq(a: ClassExoticInfo[]) {
       var seen: any = {};
       return a.filter(function (item) {
         var k = item.item.hash;
@@ -87,6 +89,12 @@ export class DesiredExoticSelectionComponent implements OnInit, OnDestroy {
       uniq(armors.filter((a) => a.item.slot == ArmorSlot.ArmorSlotChest)),
       uniq(armors.filter((a) => a.item.slot == ArmorSlot.ArmorSlotLegs)),
     ];
+  }
+
+  setAllowCollectionRolls(allow: boolean) {
+    this.config.modifyConfiguration((c) => {
+      c.includeCollectionRolls = allow;
+    });
   }
 
   selectExotic(hash: number, $event: any) {

--- a/src/app/components/authenticated-v2/subpages/armor-cluster-page/armor-cluster-page.component.ts
+++ b/src/app/components/authenticated-v2/subpages/armor-cluster-page/armor-cluster-page.component.ts
@@ -16,7 +16,7 @@
  */
 
 import { AfterViewInit, Component } from "@angular/core";
-import { IInventoryArmor } from "../../../../data/types/IInventoryArmor";
+import { IInventoryArmor, InventoryArmorSource } from "../../../../data/types/IInventoryArmor";
 import { DatabaseService } from "../../../../services/database.service";
 import { MatSnackBar } from "@angular/material/snack-bar";
 import { InventoryService } from "../../../../services/inventory.service";
@@ -454,7 +454,10 @@ export class ArmorClusterPageComponent implements AfterViewInit {
   }
 
   public async Update() {
-    var items = await this.db.inventoryArmor.toArray();
+    var items = (await this.db.inventoryArmor.toArray()).filter(
+      (item) => item.source === InventoryArmorSource.Inventory
+    );
+
     var clusters: IInventoryArmor[][] = [];
     for (let i = 0; i < this.clusterInformation.length; i++) {
       clusters.push([]);

--- a/src/app/components/authenticated-v2/subpages/armor-investigation-page/armor-investigation-page.component.ts
+++ b/src/app/components/authenticated-v2/subpages/armor-investigation-page/armor-investigation-page.component.ts
@@ -19,7 +19,7 @@ import { Component, OnDestroy, OnInit } from "@angular/core";
 import { Subject } from "rxjs";
 import { debounceTime, takeUntil } from "rxjs/operators";
 import { InventoryService } from "../../../../services/inventory.service";
-import { IInventoryArmor } from "../../../../data/types/IInventoryArmor";
+import { IInventoryArmor, InventoryArmorSource } from "../../../../data/types/IInventoryArmor";
 import { DatabaseService } from "../../../../services/database.service";
 import { IManifestArmor } from "../../../../data/types/IManifestArmor";
 import { ArmorSlot } from "../../../../data/enum/armor-slot";
@@ -111,6 +111,7 @@ export class ArmorInvestigationPageComponent implements OnInit, OnDestroy {
     this.plugData = plugData;
 
     let armorItems = ((await this.db.inventoryArmor.toArray()) as IInventoryArmor[])
+      .filter((i) => i.source === InventoryArmorSource.Inventory)
       .sort((a, b) => ("" + a.name).localeCompare(b.name))
       .map((i: IInventoryArmor) => {
         var result = {

--- a/src/app/data/buildConfiguration.ts
+++ b/src/app/data/buildConfiguration.ts
@@ -79,6 +79,7 @@ export class BuildConfiguration {
   useFotlArmor = true;
   allowBlueArmorPieces = true;
   ignoreSunsetArmor = false;
+  includeVendorRolls = false;
   includeCollectionRolls = false;
   assumeLegendariesMasterworked = true;
   assumeExoticsMasterworked = true;
@@ -116,6 +117,7 @@ export class BuildConfiguration {
       onlyUseMasterworkedItems: false,
       ignoreSunsetArmor: false,
       includeCollectionRolls: false,
+      includeVendorRolls: false,
       allowBlueArmorPieces: true,
       assumeLegendariesMasterworked: true,
       assumeExoticsMasterworked: true,

--- a/src/app/data/buildConfiguration.ts
+++ b/src/app/data/buildConfiguration.ts
@@ -79,6 +79,7 @@ export class BuildConfiguration {
   useFotlArmor = true;
   allowBlueArmorPieces = true;
   ignoreSunsetArmor = false;
+  includeCollectionRolls = false;
   assumeLegendariesMasterworked = true;
   assumeExoticsMasterworked = true;
   assumeClassItemMasterworked = true;
@@ -114,6 +115,7 @@ export class BuildConfiguration {
       maximumStatMods: MAXIMUM_STAT_MOD_AMOUNT,
       onlyUseMasterworkedItems: false,
       ignoreSunsetArmor: false,
+      includeCollectionRolls: false,
       allowBlueArmorPieces: true,
       assumeLegendariesMasterworked: true,
       assumeExoticsMasterworked: true,

--- a/src/app/data/database.ts
+++ b/src/app/data/database.ts
@@ -21,12 +21,13 @@ export function buildDb(onUpgrade: () => void) {
   const db = new Dexie("d2armorpicker-v2");
 
   // Declare tables, IDs and indexes
-  db.version(23)
+  db.version(24)
     .stores({
       manifestArmor: "id++, hash, isExotic",
       inventoryArmor:
         "id++, itemInstanceId, isExotic, hash, name, masterworked, clazz, slot, source",
       manifestCollectibles: "id++, hash",
+      vendorNames: "id++, vendorId",
     })
     .upgrade(async (tx) => {
       await onUpgrade();

--- a/src/app/data/database.ts
+++ b/src/app/data/database.ts
@@ -21,10 +21,11 @@ export function buildDb(onUpgrade: () => void) {
   const db = new Dexie("d2armorpicker-v2");
 
   // Declare tables, IDs and indexes
-  db.version(22)
+  db.version(23)
     .stores({
       manifestArmor: "id++, hash, isExotic",
-      inventoryArmor: "id++, itemInstanceId, isExotic, hash, name, masterworked, clazz, slot",
+      inventoryArmor:
+        "id++, itemInstanceId, isExotic, hash, name, masterworked, clazz, slot, source",
       manifestCollectibles: "id++, hash",
     })
     .upgrade(async (tx) => {

--- a/src/app/data/database.ts
+++ b/src/app/data/database.ts
@@ -21,10 +21,11 @@ export function buildDb(onUpgrade: () => void) {
   const db = new Dexie("d2armorpicker-v2");
 
   // Declare tables, IDs and indexes
-  db.version(19)
+  db.version(22)
     .stores({
       manifestArmor: "id++, hash, isExotic",
       inventoryArmor: "id++, itemInstanceId, isExotic, hash, name, masterworked, clazz, slot",
+      manifestCollectibles: "id++, hash",
     })
     .upgrade(async (tx) => {
       await onUpgrade();

--- a/src/app/data/enum/armor-source.ts
+++ b/src/app/data/enum/armor-source.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2023 D2ArmorPicker by Mijago.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { EnumDictionary } from "../types/EnumDictionary";
+import { InventoryArmorSource } from "../types/IInventoryArmor";
+
+export const InventoryArmorSourceNames: EnumDictionary<InventoryArmorSource, string> = {
+  [InventoryArmorSource.Inventory]: "Inventory",
+  [InventoryArmorSource.Collections]: "Collections",
+  [InventoryArmorSource.Vendor]: "Vendor",
+};

--- a/src/app/data/types/IInventoryArmor.ts
+++ b/src/app/data/types/IInventoryArmor.ts
@@ -97,3 +97,17 @@ export function applyInvestmentStats(
   r.intellect = investmentStats[144602215];
   r.strength = investmentStats[4244567218];
 }
+
+// Returns true if the items are effectively equal in stats
+export function isEqualItem(a: IInventoryArmor, b: IInventoryArmor): boolean {
+  return (
+    a.slot === b.slot &&
+    a.hash === b.hash &&
+    a.mobility === b.mobility &&
+    a.resilience === b.resilience &&
+    a.recovery === b.recovery &&
+    a.discipline === b.discipline &&
+    a.intellect === b.intellect &&
+    a.strength === b.strength
+  );
+}

--- a/src/app/data/types/IInventoryArmor.ts
+++ b/src/app/data/types/IInventoryArmor.ts
@@ -45,6 +45,8 @@ export function createArmorItem(
   itemInstanceId: string,
   source: InventoryArmorSource
 ): IInventoryArmor {
+  if (!manifestItem) throw new Error("Missing manifest item");
+
   const item: IInventoryArmor = Object.assign(
     {
       id: -1,
@@ -64,5 +66,30 @@ export function createArmorItem(
     manifestItem
   );
   (item as any).id = undefined;
+
+  // HALLOWEEN MASKS
+  if (
+    manifestItem.hash == 2545426109 ||
+    manifestItem.hash == 199733460 ||
+    manifestItem.hash == 3224066584
+  ) {
+    item.slot = ArmorSlot.ArmorSlotHelmet;
+  }
+
   return item;
+}
+
+// This will mutate the incoming armor item to add the relevant stats
+// plugHashes is received as a simple array of hashes,
+// as the data is in a different shape for instances vs manifest items
+export function applyInvestmentStats(
+  r: IInventoryArmor,
+  investmentStats: { [id: number]: number }
+) {
+  r.mobility = investmentStats[2996146975];
+  r.resilience = investmentStats[392767087];
+  r.recovery = investmentStats[1943323491];
+  r.discipline = investmentStats[1735777505];
+  r.intellect = investmentStats[144602215];
+  r.strength = investmentStats[4244567218];
 }

--- a/src/app/data/types/IInventoryArmor.ts
+++ b/src/app/data/types/IInventoryArmor.ts
@@ -39,7 +39,7 @@ export interface IInventoryArmor extends IManifestArmor {
   energyLevel: number;
 
   // Note: this will be empty for vendor items
-  statPlugHashes: (number | undefined)[];
+  statPlugHashes?: (number | undefined)[];
 
   source: InventoryArmorSource;
 }
@@ -56,7 +56,6 @@ export function createArmorItem(
       id: -1,
       itemInstanceId,
       mayBeBugged: false,
-      statPlugHashes: [],
       masterworked: false,
       energyLevel: 0,
       mobility: 0,

--- a/src/app/data/types/IInventoryArmor.ts
+++ b/src/app/data/types/IInventoryArmor.ts
@@ -22,6 +22,7 @@ import { DestinyEnergyType } from "bungie-api-ts/destiny2/interfaces";
 export enum InventoryArmorSource {
   Inventory = 0,
   Collections = 1,
+  Vendor = 2,
 }
 
 export interface IInventoryArmor extends IManifestArmor {
@@ -36,7 +37,10 @@ export interface IInventoryArmor extends IManifestArmor {
   intellect: number;
   strength: number;
   energyLevel: number;
+
+  // Note: this will be empty for vendor items
   statPlugHashes: (number | undefined)[];
+
   source: InventoryArmorSource;
 }
 

--- a/src/app/data/types/IInventoryArmor.ts
+++ b/src/app/data/types/IInventoryArmor.ts
@@ -15,8 +15,14 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { ArmorSlot } from "../enum/armor-slot";
 import { IManifestArmor } from "./IManifestArmor";
 import { DestinyEnergyType } from "bungie-api-ts/destiny2/interfaces";
+
+export enum InventoryArmorSource {
+  Inventory = 0,
+  Collections = 1,
+}
 
 export interface IInventoryArmor extends IManifestArmor {
   id: number;
@@ -31,4 +37,32 @@ export interface IInventoryArmor extends IManifestArmor {
   strength: number;
   energyLevel: number;
   statPlugHashes: (number | undefined)[];
+  source: InventoryArmorSource;
+}
+
+export function createArmorItem(
+  manifestItem: IManifestArmor,
+  itemInstanceId: string,
+  source: InventoryArmorSource
+): IInventoryArmor {
+  const item: IInventoryArmor = Object.assign(
+    {
+      id: -1,
+      itemInstanceId,
+      mayBeBugged: false,
+      statPlugHashes: [],
+      masterworked: false,
+      energyLevel: 0,
+      mobility: 0,
+      resilience: 0,
+      recovery: 0,
+      discipline: 0,
+      intellect: 0,
+      strength: 0,
+      source,
+    },
+    manifestItem
+  );
+  (item as any).id = undefined;
+  return item;
 }

--- a/src/app/data/types/IManifestArmor.ts
+++ b/src/app/data/types/IManifestArmor.ts
@@ -18,6 +18,7 @@
 import {
   DestinyClass,
   DestinyItemInvestmentStatDefinition,
+  DestinyItemSocketEntryDefinition,
   TierType,
 } from "bungie-api-ts/destiny2/interfaces";
 import { ArmorSlot } from "../enum/armor-slot";
@@ -41,4 +42,5 @@ export interface IManifestArmor {
   itemType: number;
   itemSubType: number;
   investmentStats: DestinyItemInvestmentStatDefinition[];
+  socketEntries: DestinyItemSocketEntryDefinition[];
 }

--- a/src/app/data/types/IManifestCollectible.ts
+++ b/src/app/data/types/IManifestCollectible.ts
@@ -1,0 +1,4 @@
+export interface IManifestCollectible {
+  hash: number;
+  itemHash: number;
+}

--- a/src/app/data/types/IVendorInfo.ts
+++ b/src/app/data/types/IVendorInfo.ts
@@ -1,0 +1,4 @@
+export interface IVendorInfo {
+  vendorId: number;
+  vendorName: string;
+}

--- a/src/app/services/bungie-api.service.ts
+++ b/src/app/services/bungie-api.service.ts
@@ -670,16 +670,18 @@ export class BungieApiService {
         if ((v.itemCategoryHashes?.indexOf(49) || -1) > -1) slot = ArmorSlot.ArmorSlotClass;
 
         const isArmor2 =
-          (v.sockets?.socketEntries.filter((d) => {
-            return (
-              d.socketTypeHash == 2512726577 || // general
-              d.socketTypeHash == 1108765570 || // arms
-              d.socketTypeHash == 959256494 || // chest
-              d.socketTypeHash == 2512726577 || // class
-              d.socketTypeHash == 3219375296 || // legs
-              d.socketTypeHash == 968742181
-            ); // head
-          }).length || []) > 0;
+          (
+            v.sockets?.socketEntries.filter((d) => {
+              return (
+                d.socketTypeHash == 2512726577 || // general
+                d.socketTypeHash == 1108765570 || // arms
+                d.socketTypeHash == 959256494 || // chest
+                d.socketTypeHash == 2512726577 || // class
+                d.socketTypeHash == 3219375296 || // legs
+                d.socketTypeHash == 968742181 // head
+              );
+            }) || []
+          ).length > 0;
 
         const isExotic = v.inventory?.tierTypeName == "Exotic" ? 1 : 0;
         let exoticPerkHash = null;

--- a/src/app/services/bungie-api.service.ts
+++ b/src/app/services/bungie-api.service.ts
@@ -72,13 +72,15 @@ function collectInvestmentStats(
       investmentStats[newStats.statTypeHash] += newStats.value;
   }
 
-  const plugs = [plugHashes[6], plugHashes[7], plugHashes[8], plugHashes[9]];
-  r.statPlugHashes = plugs;
-  var plm = plugs.map((k) => mods[k || ""]).filter((k) => k != null);
-  for (let entry of plm) {
-    for (let newStats of entry.investmentStats) {
-      if (newStats.statTypeHash in investmentStats)
-        investmentStats[newStats.statTypeHash] += newStats.value;
+  if (r.slot != ArmorSlot.ArmorSlotClass) {
+    const plugs = [plugHashes[6], plugHashes[7], plugHashes[8], plugHashes[9]];
+    r.statPlugHashes = plugs;
+    var plm = plugs.map((k) => mods[k || ""]).filter((k) => k != null);
+    for (let entry of plm) {
+      for (let newStats of entry.investmentStats) {
+        if (newStats.statTypeHash in investmentStats)
+          investmentStats[newStats.statTypeHash] += newStats.value;
+      }
     }
   }
 

--- a/src/app/services/bungie-api.service.ts
+++ b/src/app/services/bungie-api.service.ts
@@ -191,7 +191,7 @@ export class BungieApiService {
   // Collect the list of unlocked exotic armor pieces
   private async getUnlockedExoticArmor(
     characterCollectibles: Record<string, DestinyCollectiblesComponent>
-  ) {
+  ): Promise<Set<number>> {
     const manifestExoticArmorItemHashes = (await this.db.manifestCollectibles.toArray()).reduce(
       (acc, cur) => {
         acc[cur.hash] = cur.itemHash;
@@ -200,7 +200,7 @@ export class BungieApiService {
       {} as Record<number, number>
     );
 
-    return Object.values(characterCollectibles)
+    const itemHashes = Object.values(characterCollectibles)
       .flatMap((char) => Object.entries(char.collectibles ?? {}))
       .filter(([hash, { state }]) => {
         return (
@@ -209,6 +209,8 @@ export class BungieApiService {
         );
       })
       .map(([hash, _]) => manifestExoticArmorItemHashes[parseInt(hash)]);
+
+    return new Set(itemHashes);
   }
 
   async updateArmorItems(force = false) {
@@ -351,7 +353,7 @@ export class BungieApiService {
       .filter(Boolean) as IInventoryArmor[];
 
     // Now add the collection rolls for exotics
-    const collectionRollItems = unlockedExoticArmorItemHashes
+    const collectionRollItems = Array.from(unlockedExoticArmorItemHashes)
       .map((exoticItemHash) => {
         const manifestArmorItem = res[exoticItemHash];
         if (!manifestArmorItem) {

--- a/src/app/services/bungie-api.service.ts
+++ b/src/app/services/bungie-api.service.ts
@@ -48,6 +48,7 @@ import { ArmorPerkOrSlot } from "../data/enum/armor-stat";
 import { ConfigurationService } from "./configuration.service";
 import { IManifestCollectible } from "../data/types/IManifestCollectible";
 import { MembershipService } from "./membership.service";
+import { VendorsService } from "./vendors.service";
 import { HttpClientService } from "./http-client.service";
 
 function collectInvestmentStats(
@@ -95,7 +96,8 @@ export class BungieApiService {
     private http: HttpClientService,
     private db: DatabaseService,
     private config: ConfigurationService,
-    private membership: MembershipService
+    private membership: MembershipService,
+    private vendors: VendorsService
   ) {
     this.config.configuration.subscribe(async (config) => {
       this.config_assumeEveryLegendaryIsArtifice = config.assumeEveryLegendaryIsArtifice;
@@ -246,6 +248,8 @@ export class BungieApiService {
       destinyMembershipId: destinyMembership.membershipId,
     });
 
+    const vendorArmorItems = await this.vendors.getVendorArmorItems();
+
     const unlockedExoticArmorItemHashes = await this.getUnlockedExoticArmor(
       profile.Response.characterCollectibles.data ?? {}
     );
@@ -375,6 +379,8 @@ export class BungieApiService {
     r = r.concat(collectionRollItems);
 
     r = r.filter((k) => !k["statPlugHashes"] || k["statPlugHashes"][0] != null);
+
+    r = r.concat(vendorArmorItems);
 
     // Now add the stuff to the db..
     await this.db.inventoryArmor.clear();

--- a/src/app/services/bungie-api.service.ts
+++ b/src/app/services/bungie-api.service.ts
@@ -252,7 +252,7 @@ export class BungieApiService {
       destinyMembershipId: destinyMembership.membershipId,
     });
 
-    const vendorArmorItems = await this.vendors.getVendorArmorItems();
+    await this.vendors.updateVendorArmorItemsCache();
 
     const unlockedExoticArmorItemHashes = await this.getUnlockedExoticArmor(
       profile.Response.characterCollectibles.data ?? {}
@@ -384,11 +384,10 @@ export class BungieApiService {
 
     r = r.filter((k) => !k["statPlugHashes"] || k["statPlugHashes"][0] != null);
 
-    r = r.concat(vendorArmorItems);
-
-    // Now add the stuff to the db..
-    await this.db.inventoryArmor.clear();
+    await this.db.inventoryArmor.where({ source: InventoryArmorSource.Inventory }).delete();
+    await this.db.inventoryArmor.where({ source: InventoryArmorSource.Collections }).delete();
     await this.db.inventoryArmor.bulkAdd(r);
+
     localStorage.setItem("LastArmorUpdate", Date.now().toString());
     localStorage.setItem("last-armor-db-name", this.db.inventoryArmor.db.name);
 

--- a/src/app/services/bungie-api.service.ts
+++ b/src/app/services/bungie-api.service.ts
@@ -33,12 +33,10 @@ import {
   DestinyCollectiblesComponent,
   DestinyItemInvestmentStatDefinition,
 } from "bungie-api-ts/destiny2";
-import { getMembershipDataForCurrentUser } from "bungie-api-ts/user";
 import { AuthService } from "./auth.service";
 import { HttpClient } from "@angular/common/http";
 import { DatabaseService } from "./database.service";
 import { environment } from "../../environments/environment";
-import { BungieMembershipType } from "bungie-api-ts/common";
 import { IManifestArmor } from "../data/types/IManifestArmor";
 import {
   IInventoryArmor,
@@ -49,6 +47,7 @@ import { ArmorSlot } from "../data/enum/armor-slot";
 import { ArmorPerkOrSlot } from "../data/enum/armor-stat";
 import { ConfigurationService } from "./configuration.service";
 import { IManifestCollectible } from "../data/types/IManifestCollectible";
+import { MembershipService } from "./membership.service";
 
 // This will mutate the incoming armor item to add the relevant stats
 // plugHashes is received as a simple array of hashes,
@@ -102,7 +101,8 @@ export class BungieApiService {
     private authService: AuthService,
     private http: HttpClient,
     private db: DatabaseService,
-    private config: ConfigurationService
+    private config: ConfigurationService,
+    private membership: MembershipService
   ) {
     this.config.configuration.subscribe(async (config) => {
       this.config_assumeEveryLegendaryIsArtifice = config.assumeEveryLegendaryIsArtifice;
@@ -160,37 +160,12 @@ export class BungieApiService {
       });
   }
 
-  async getCharacters() {
-    let destinyMembership = await this.getMembershipDataForCurrentUser();
-    if (!destinyMembership) {
-      await this.authService.logout();
-      return [];
-    }
-
-    const profile = await getProfile((d) => this.$http(d), {
-      components: [DestinyComponentType.Characters],
-      membershipType: destinyMembership.membershipType,
-      destinyMembershipId: destinyMembership.membershipId,
-    });
-
-    return (
-      Object.values(profile?.Response.characters.data || {}).map((d) => {
-        return {
-          characterId: d.characterId,
-          clazz: d.classType as DestinyClass,
-          emblemUrl: d.emblemBackgroundPath,
-          lastPlayed: Date.parse(d.dateLastPlayed),
-        };
-      }) || []
-    );
-  }
-
   async transferItem(
     itemInstanceId: string,
     targetCharacter: string,
     equip = false
   ): Promise<boolean> {
-    let destinyMembership = await this.getMembershipDataForCurrentUser();
+    let destinyMembership = await this.membership.getMembershipDataForCurrentUser();
     if (!destinyMembership) {
       await this.authService.logout();
       return false;
@@ -244,7 +219,7 @@ export class BungieApiService {
 
   async moveItemToVault(itemInstanceId: string) {
     console.info("moveItemToVault", itemInstanceId);
-    let destinyMembership = await this.getMembershipDataForCurrentUser();
+    let destinyMembership = await this.membership.getMembershipDataForCurrentUser();
     if (!destinyMembership) {
       await this.authService.logout();
       return;
@@ -267,58 +242,6 @@ export class BungieApiService {
     };
 
     await transferItem((d) => this.$httpPost(d), payload);
-  }
-
-  async getMembershipDataForCurrentUser() {
-    var membershipData = JSON.parse(localStorage.getItem("auth-membershipInfo") || "null");
-    var membershipDataAge = JSON.parse(localStorage.getItem("auth-membershipInfo-date") || "0");
-    if (membershipData && Date.now() - membershipDataAge < 1000 * 60 * 60 * 24) {
-      console.log("getMembershipDataForCurrentUser -> loading cached! ");
-      return membershipData;
-    }
-
-    console.info("BungieApiService", "getMembershipDataForCurrentUser");
-    let response = await getMembershipDataForCurrentUser((d) => this.$http(d));
-    let memberships = response?.Response.destinyMemberships;
-    console.info("Memberships:", memberships);
-    memberships = memberships.filter(
-      (m) => m.crossSaveOverride == 0 || m.crossSaveOverride == m.membershipType
-    );
-    console.info("Filtered Memberships:", memberships);
-
-    let result = null;
-    if (memberships?.length == 1) {
-      // This guardian only has one account linked, so we can proceed as normal
-      result = memberships?.[0];
-    } else {
-      // This guardian has multiple accounts linked.
-      // Fetch the last login time for each account, and use the one that was most recently used.
-      let lastLoggedInProfileIndex: any = 0;
-      let lastPlayed = 0;
-      for (let id in memberships) {
-        const membership = memberships?.[id];
-        const profile = await getProfile((d) => this.$http(d), {
-          components: [DestinyComponentType.Profiles],
-          membershipType: membership.membershipType,
-          destinyMembershipId: membership.membershipId,
-        });
-        if (!!profile && profile.Response?.profile.data?.dateLastPlayed) {
-          let date = Date.parse(profile.Response?.profile.data?.dateLastPlayed);
-          if (date > lastPlayed) {
-            lastPlayed = date;
-            lastLoggedInProfileIndex = id;
-          }
-        }
-      }
-      console.info(
-        "getMembershipDataForCurrentUser",
-        "Selected membership data for the last logged in membership."
-      );
-      result = memberships?.[lastLoggedInProfileIndex];
-    }
-    localStorage.setItem("auth-membershipInfo", JSON.stringify(result));
-    localStorage.setItem("auth-membershipInfo-date", JSON.stringify(Date.now()));
-    return result;
   }
 
   // Collect the list of unlocked exotic armor pieces
@@ -357,7 +280,7 @@ export class BungieApiService {
           (1000 * 3600) / 2
         )
           return;
-    let destinyMembership = await this.getMembershipDataForCurrentUser();
+    let destinyMembership = await this.membership.getMembershipDataForCurrentUser();
     if (!destinyMembership) {
       await this.authService.logout();
       return;

--- a/src/app/services/bungie-api.service.ts
+++ b/src/app/services/bungie-api.service.ts
@@ -402,40 +402,39 @@ export class BungieApiService {
     )
       return ArmorPerkOrSlot.GuardianGamesClassItem;
 
-    const scks = v.sockets?.socketEntries;
-    if ((scks?.filter((d) => d.reusablePlugSetHash == 1280) || []).length > 0)
-      return ArmorPerkOrSlot.SlotArtifice;
-    if ((scks?.filter((d) => d.singleInitialItemHash == 3727270518) || []).length > 0)
+    const scks = v.sockets?.socketEntries ?? [];
+    if (scks.find((d) => d.reusablePlugSetHash == 1280)) return ArmorPerkOrSlot.SlotArtifice;
+    if (scks.find((d) => d.singleInitialItemHash == 3727270518))
       return ArmorPerkOrSlot.SlotArtifice;
 
-    if ((scks?.filter((d) => d.singleInitialItemHash == 2779380852) || []).length > 0)
+    if (scks.find((d) => d.singleInitialItemHash == 2779380852))
       return ArmorPerkOrSlot.SonarAmplifier;
-    if ((scks?.filter((d) => d.singleInitialItemHash == 4144354978) || []).length > 0)
+    if (scks.find((d) => d.singleInitialItemHash == 4144354978))
       return ArmorPerkOrSlot.SlotRootOfNightmares;
-    if ((scks?.filter((d) => d.singleInitialItemHash == 1728096240) || []).length > 0)
+    if (scks.find((d) => d.singleInitialItemHash == 1728096240))
       return ArmorPerkOrSlot.SlotKingsFall;
-    if ((scks?.filter((d) => d.singleInitialItemHash == 1679876242) || []).length > 0)
+    if (scks.find((d) => d.singleInitialItemHash == 1679876242))
       return ArmorPerkOrSlot.SlotLastWish;
-    if ((scks?.filter((d) => d.singleInitialItemHash == 3738398030) || []).length > 0)
+    if (scks.find((d) => d.singleInitialItemHash == 3738398030))
       return ArmorPerkOrSlot.SlotVaultOfGlass;
-    if ((scks?.filter((d) => d.singleInitialItemHash == 706611068) || []).length > 0)
+    if (scks.find((d) => d.singleInitialItemHash == 706611068))
       return ArmorPerkOrSlot.SlotGardenOfSalvation;
-    if ((scks?.filter((d) => d.singleInitialItemHash == 4055462131) || []).length > 0)
+    if (scks.find((d) => d.singleInitialItemHash == 4055462131))
       return ArmorPerkOrSlot.SlotDeepStoneCrypt;
-    if ((scks?.filter((d) => d.singleInitialItemHash == 2447143568) || []).length > 0)
+    if (scks.find((d) => d.singleInitialItemHash == 2447143568))
       return ArmorPerkOrSlot.SlotVowOfTheDisciple;
 
-    if ((scks?.filter((d) => d.singleInitialItemHash == 1101259514) || []).length > 0)
+    if (scks.find((d) => d.singleInitialItemHash == 1101259514))
       return ArmorPerkOrSlot.PerkQueensFavor;
-    if ((scks?.filter((d) => d.singleInitialItemHash == 1180997867) || []).length > 0)
+    if (scks.find((d) => d.singleInitialItemHash == 1180997867))
       return ArmorPerkOrSlot.SlotNightmare;
-    if ((scks?.filter((d) => d.singleInitialItemHash == 2472875850) || []).length > 0)
+    if (scks.find((d) => d.singleInitialItemHash == 2472875850))
       return ArmorPerkOrSlot.PerkIronBanner;
-    if ((scks?.filter((d) => d.singleInitialItemHash == 2392155347) || []).length > 0)
+    if (scks.find((d) => d.singleInitialItemHash == 2392155347))
       return ArmorPerkOrSlot.PerkUniformedOfficer;
-    if ((scks?.filter((d) => d.singleInitialItemHash == 400659041) || []).length > 0)
+    if (scks.find((d) => d.singleInitialItemHash == 400659041))
       return ArmorPerkOrSlot.PerkPlunderersTrappings;
-    if ((scks?.filter((d) => d.singleInitialItemHash == 3525583702) || []).length > 0)
+    if (scks.find((d) => d.singleInitialItemHash == 3525583702))
       return ArmorPerkOrSlot.SeraphSensorArray;
 
     return ArmorPerkOrSlot.None;

--- a/src/app/services/database.service.ts
+++ b/src/app/services/database.service.ts
@@ -23,6 +23,7 @@ import { IManifestArmor } from "../data/types/IManifestArmor";
 import { IInventoryArmor } from "../data/types/IInventoryArmor";
 import { IManifestCollectible } from "../data/types/IManifestCollectible";
 import { environment } from "../../environments/environment";
+import { IVendorInfo } from "../data/types/IVendorInfo";
 
 @Injectable({
   providedIn: "root",
@@ -36,6 +37,9 @@ export class DatabaseService {
   // Maps the collectible hash to the inventory item hash
   public manifestCollectibles: Dexie.Table<IManifestCollectible>;
 
+  // Maps the vendor id to the vendor name
+  public vendorNames: Dexie.Table<IVendorInfo, number>;
+
   constructor(private auth: AuthService) {
     this.db = buildDb(async () => {
       await this.auth.clearManifestInfo();
@@ -43,6 +47,7 @@ export class DatabaseService {
     this.manifestArmor = this.db.table("manifestArmor");
     this.inventoryArmor = this.db.table("inventoryArmor");
     this.manifestCollectibles = this.db.table("manifestCollectibles");
+    this.vendorNames = this.db.table("vendorNames");
 
     this.auth.logoutEvent.subscribe(async (k) => {
       await this.clearDatabase();
@@ -56,6 +61,7 @@ export class DatabaseService {
     this.manifestArmor = this.db.table("manifestArmor");
     this.inventoryArmor = this.db.table("inventoryArmor");
     this.manifestCollectibles = this.db.table("manifestCollectibles");
+    this.vendorNames = this.db.table("vendorNames");
   }
 
   async writeManifestArmor(items: IManifestArmor[], version: string) {

--- a/src/app/services/database.service.ts
+++ b/src/app/services/database.service.ts
@@ -21,6 +21,7 @@ import { AuthService } from "./auth.service";
 import { buildDb } from "../data/database";
 import { IManifestArmor } from "../data/types/IManifestArmor";
 import { IInventoryArmor } from "../data/types/IInventoryArmor";
+import { IManifestCollectible } from "../data/types/IManifestCollectible";
 
 @Injectable({
   providedIn: "root",
@@ -31,12 +32,16 @@ export class DatabaseService {
   public manifestArmor: Dexie.Table<IManifestArmor, number>;
   public inventoryArmor: Dexie.Table<IInventoryArmor, number>;
 
+  // Maps the collectible hash to the inventory item hash
+  public manifestCollectibles: Dexie.Table<IManifestCollectible>;
+
   constructor(private auth: AuthService) {
     this.db = buildDb(async () => {
       await this.auth.clearManifestInfo();
     });
     this.manifestArmor = this.db.table("manifestArmor");
     this.inventoryArmor = this.db.table("inventoryArmor");
+    this.manifestCollectibles = this.db.table("manifestCollectibles");
 
     this.auth.logoutEvent.subscribe(async (k) => {
       await this.clearDatabase();
@@ -49,6 +54,7 @@ export class DatabaseService {
     });
     this.manifestArmor = this.db.table("manifestArmor");
     this.inventoryArmor = this.db.table("inventoryArmor");
+    this.manifestCollectibles = this.db.table("manifestCollectibles");
   }
 
   private async clearDatabase() {

--- a/src/app/services/http-client.service.ts
+++ b/src/app/services/http-client.service.ts
@@ -1,0 +1,63 @@
+import { Injectable } from "@angular/core";
+import { HttpClientConfig } from "bungie-api-ts/destiny2";
+import { AuthService } from "./auth.service";
+import { HttpClient } from "@angular/common/http";
+import { environment } from "../../environments/environment";
+
+@Injectable({
+  providedIn: "root",
+})
+export class HttpClientService {
+  constructor(private authService: AuthService, private http: HttpClient) {}
+
+  async $httpWithoutKey(config: HttpClientConfig) {
+    return this.http
+      .get<any>(config.url, {
+        params: config.params,
+      })
+      .toPromise();
+  }
+
+  async $httpPost(config: HttpClientConfig) {
+    return this.http
+      .post<any>(config.url, config.body, {
+        params: config.params,
+        headers: {
+          "X-API-Key": environment.apiKey,
+          Authorization: "Bearer " + this.authService.accessToken,
+        },
+      })
+      .toPromise()
+      .catch(async (err) => {
+        console.error(err);
+      });
+  }
+
+  async $http(config: HttpClientConfig) {
+    return this.http
+      .get<any>(config.url, {
+        params: config.params,
+        headers: {
+          "X-API-Key": environment.apiKey,
+          Authorization: "Bearer " + this.authService.accessToken,
+        },
+      })
+      .toPromise()
+      .catch(async (err) => {
+        console.error(err);
+        if (environment.offlineMode) {
+          console.debug("Offline mode, ignoring API error");
+          return;
+        }
+        if (err.error?.ErrorStatus == "SystemDisabled") {
+          console.info("System is disabled. Revoking auth, must re-login");
+          await this.authService.logout();
+        }
+        if (err.ErrorStatus != "Internal Server Error") {
+          console.info("API-Error");
+          //await this.authService.logout();
+        }
+        // TODO: go to login page
+      });
+  }
+}

--- a/src/app/services/inventory.service.ts
+++ b/src/app/services/inventory.service.ts
@@ -284,6 +284,7 @@ export class InventoryService {
           instances.find((i) => i.source === InventoryArmorSource.Collections) !== undefined,
         inInventory:
           instances.find((i) => i.source === InventoryArmorSource.Inventory) !== undefined,
+        inVendor: instances.find((i) => i.source === InventoryArmorSource.Vendor) !== undefined,
       };
     });
   }

--- a/src/app/services/inventory.service.ts
+++ b/src/app/services/inventory.service.ts
@@ -45,6 +45,7 @@ type info = {
 export type ClassExoticInfo = {
   inInventory: boolean;
   inCollection: boolean;
+  inVendor: boolean;
   item: IManifestArmor;
 };
 

--- a/src/app/services/inventory.service.ts
+++ b/src/app/services/inventory.service.ts
@@ -256,9 +256,6 @@ export class InventoryService {
     }
   }
 
-  // I don’t think this is used?
-  // public exoticsForClass: Array<IManifestArmor> = [];
-
   async getItemCountForClass(clazz: CharacterClass, slot?: ArmorSlot) {
     let pieces = await this.db.inventoryArmor.where("clazz").equals(clazz).toArray();
     if (!!slot) pieces = pieces.filter((i) => i.slot == slot);
@@ -276,7 +273,6 @@ export class InventoryService {
       (d) => d.clazz == (clazz as any) && d.armor2 && (!slot || d.slot == slot)
     );
 
-    // this.exoticsForClass = exotics;
     return exotics.map((ex) => {
       const instances = inventory.filter((i) => i.hash == ex.hash);
       return {

--- a/src/app/services/inventory.service.ts
+++ b/src/app/services/inventory.service.ts
@@ -30,7 +30,8 @@ import { AuthService } from "./auth.service";
 import { ArmorSlot } from "../data/enum/armor-slot";
 import { NavigationEnd, Router } from "@angular/router";
 import { ResultDefinition } from "../components/authenticated-v2/results/results.component";
-import { InventoryArmorSource } from "../data/types/IInventoryArmor";
+import { IInventoryArmor, InventoryArmorSource } from "../data/types/IInventoryArmor";
+import { ItemBindStatus } from "bungie-api-ts/destiny2";
 
 type info = {
   results: ResultDefinition[];
@@ -207,6 +208,19 @@ export class InventoryService {
             for (let result of results) {
               endResults.push(...result);
             }
+
+            // add extra fields for collection and vendor rolls
+            endResults = endResults.map((r) => {
+              r.usesCollectionRoll = r.items.some(
+                (i: IInventoryArmor[]) => i[0].source === InventoryArmorSource.Collections
+              );
+              r.usesVendorRoll = r.items.some(
+                (i: IInventoryArmor[]) => i[0].source === InventoryArmorSource.Vendor
+              );
+              return r;
+            });
+
+            console.debug("endResults", endResults);
 
             this._armorResults.next({
               results: endResults,

--- a/src/app/services/membership.service.ts
+++ b/src/app/services/membership.service.ts
@@ -1,0 +1,125 @@
+import { Injectable } from "@angular/core";
+
+import { environment } from "../../environments/environment";
+import {
+  HttpClientConfig,
+  DestinyComponentType,
+  getProfile,
+  DestinyClass,
+} from "bungie-api-ts/destiny2";
+import { AuthService } from "./auth.service";
+import { GroupUserInfoCard } from "bungie-api-ts/groupv2";
+import { getMembershipDataForCurrentUser } from "bungie-api-ts/user";
+import { HttpClient } from "@angular/common/http";
+
+@Injectable({
+  providedIn: "root",
+})
+export class MembershipService {
+  constructor(private authService: AuthService, private http: HttpClient) {}
+
+  private async $http(config: HttpClientConfig) {
+    return this.http
+      .get<any>(config.url, {
+        params: config.params,
+        headers: {
+          "X-API-Key": environment.apiKey,
+          Authorization: "Bearer " + this.authService.accessToken,
+        },
+      })
+      .toPromise()
+      .catch(async (err) => {
+        console.error(err);
+        if (environment.offlineMode) {
+          console.debug("Offline mode, ignoring API error");
+          return;
+        }
+        if (err.error?.ErrorStatus == "SystemDisabled") {
+          console.info("System is disabled. Revoking auth, must re-login");
+          await this.authService.logout();
+        }
+        if (err.ErrorStatus != "Internal Server Error") {
+          console.info("API-Error");
+          //await this.authService.logout();
+        }
+        // TODO: go to login page
+      });
+  }
+
+  async getMembershipDataForCurrentUser(): Promise<GroupUserInfoCard> {
+    var membershipData = JSON.parse(localStorage.getItem("auth-membershipInfo") || "null");
+    var membershipDataAge = JSON.parse(localStorage.getItem("auth-membershipInfo-date") || "0");
+    if (membershipData && Date.now() - membershipDataAge < 1000 * 60 * 60 * 24) {
+      console.log("getMembershipDataForCurrentUser -> loading cached! ");
+      return membershipData;
+    }
+
+    console.info("BungieApiService", "getMembershipDataForCurrentUser");
+    let response = await getMembershipDataForCurrentUser((d) => this.$http(d));
+    let memberships = response?.Response.destinyMemberships;
+    console.info("Memberships:", memberships);
+    memberships = memberships.filter(
+      (m) => m.crossSaveOverride == 0 || m.crossSaveOverride == m.membershipType
+    );
+    console.info("Filtered Memberships:", memberships);
+
+    let result = null;
+    if (memberships?.length == 1) {
+      // This guardian only has one account linked, so we can proceed as normal
+      result = memberships?.[0];
+    } else {
+      // This guardian has multiple accounts linked.
+      // Fetch the last login time for each account, and use the one that was most recently used.
+      let lastLoggedInProfileIndex: any = 0;
+      let lastPlayed = 0;
+      for (let id in memberships) {
+        const membership = memberships?.[id];
+        const profile = await getProfile((d) => this.$http(d), {
+          components: [DestinyComponentType.Profiles],
+          membershipType: membership.membershipType,
+          destinyMembershipId: membership.membershipId,
+        });
+        if (!!profile && profile.Response?.profile.data?.dateLastPlayed) {
+          let date = Date.parse(profile.Response?.profile.data?.dateLastPlayed);
+          if (date > lastPlayed) {
+            lastPlayed = date;
+            lastLoggedInProfileIndex = id;
+          }
+        }
+      }
+      console.info(
+        "getMembershipDataForCurrentUser",
+        "Selected membership data for the last logged in membership."
+      );
+      result = memberships?.[lastLoggedInProfileIndex];
+    }
+    localStorage.setItem("auth-membershipInfo", JSON.stringify(result));
+    localStorage.setItem("auth-membershipInfo-date", JSON.stringify(Date.now()));
+    return result;
+  }
+
+  async getCharacters() {
+    let destinyMembership = await this.getMembershipDataForCurrentUser();
+    if (!destinyMembership) {
+      await this.authService.logout();
+      return [];
+    }
+
+    const profile = await getProfile((d) => this.$http(d), {
+      components: [DestinyComponentType.Characters],
+      membershipType: destinyMembership.membershipType,
+      destinyMembershipId: destinyMembership.membershipId,
+    });
+
+    return (
+      Object.values(profile?.Response.characters.data || {}).map((d) => {
+        return {
+          characterId: d.characterId,
+          clazz: d.classType as DestinyClass,
+          emblemUrl: d.emblemBackgroundPath,
+          lastPlayed: Date.parse(d.dateLastPlayed),
+        };
+      }) || []
+    );
+  }
+}

--- a/src/app/services/results-builder.worker.spec.ts
+++ b/src/app/services/results-builder.worker.spec.ts
@@ -20,7 +20,7 @@ import { DestinyClass, TierType } from "bungie-api-ts/destiny2";
 import { ArmorSlot } from "../data/enum/armor-slot";
 import { ArmorPerkOrSlot, ArmorStat } from "../data/enum/armor-stat";
 import { BuildConfiguration } from "../data/buildConfiguration";
-import { IInventoryArmor } from "../data/types/IInventoryArmor";
+import { IInventoryArmor, InventoryArmorSource } from "../data/types/IInventoryArmor";
 
 const plugs = [
   [1, 1, 10],
@@ -123,6 +123,7 @@ function buildTestItem(
     name: "item_" + slot,
     armor2: true,
     clazz: DestinyClass.Titan,
+    source: InventoryArmorSource.Inventory,
     description: "",
     slot: slot,
     mobility: stats[0],
@@ -148,6 +149,7 @@ function buildTestItem(
     rarity: TierType.Superior,
     rawData: undefined,
     statPlugHashes: [],
+    socketEntries: [],
     watermarkIcon: "",
   };
 }

--- a/src/app/services/results-builder.worker.ts
+++ b/src/app/services/results-builder.worker.ts
@@ -696,6 +696,7 @@ export function handlePermutation(
             instance.intellect,
             instance.strength,
           ],
+          source: instance.source,
         });
         return p;
       },

--- a/src/app/services/results-builder.worker.ts
+++ b/src/app/services/results-builder.worker.ts
@@ -16,7 +16,7 @@
  */
 
 import { BuildConfiguration } from "../data/buildConfiguration";
-import { IInventoryArmor } from "../data/types/IInventoryArmor";
+import { IInventoryArmor, InventoryArmorSource } from "../data/types/IInventoryArmor";
 import { buildDb } from "../data/database";
 import { ArmorSlot } from "../data/enum/armor-slot";
 import { FORCE_USE_NO_EXOTIC, FORCE_USE_ANY_EXOTIC } from "../data/constants";
@@ -29,7 +29,11 @@ import {
   StatModifier,
 } from "../data/enum/armor-stat";
 import { IManifestArmor } from "../data/types/IManifestArmor";
-import { TierType } from "bungie-api-ts/destiny2";
+import {
+  DestinyItemInvestmentStatDefinition,
+  DestinyItemSocketState,
+  TierType,
+} from "bungie-api-ts/destiny2";
 import { environment } from "../../environments/environment";
 
 import { precalculatedZeroWasteModCombinations } from "../data/generated/precalculatedZeroWasteModCombinations";
@@ -200,6 +204,10 @@ addEventListener("message", async ({ data }) => {
     .filter((item) => item.slot != ArmorSlot.ArmorSlotNone)
     // filter disabled items
     .filter((item) => config.disabledItems.indexOf(item.itemInstanceId) == -1)
+    // filter collection rolls if not allowed
+    .filter(
+      (item) => config.includeCollectionRolls || item.source !== InventoryArmorSource.Collections
+    )
     // filter the selected exotic right here
     .filter((item) => config.selectedExotics.indexOf(FORCE_USE_NO_EXOTIC) == -1 || !item.isExotic)
     .filter(

--- a/src/app/services/results-builder.worker.ts
+++ b/src/app/services/results-builder.worker.ts
@@ -16,7 +16,7 @@
  */
 
 import { BuildConfiguration } from "../data/buildConfiguration";
-import { IInventoryArmor, InventoryArmorSource } from "../data/types/IInventoryArmor";
+import { IInventoryArmor, InventoryArmorSource, isEqualItem } from "../data/types/IInventoryArmor";
 import { buildDb } from "../data/database";
 import { ArmorSlot } from "../data/enum/armor-slot";
 import { FORCE_USE_NO_EXOTIC, FORCE_USE_ANY_EXOTIC } from "../data/constants";
@@ -237,6 +237,19 @@ addEventListener("message", async ({ data }) => {
       );
     });
   // console.log(items.map(d => "id:'"+d.itemInstanceId+"'").join(" or "))
+
+  // Remove collection items if they are in inventory
+  items = items.filter((item) => {
+    if (item.source === InventoryArmorSource.Inventory) return true;
+
+    const purchasedItemInstance = items.find(
+      (rhs) => rhs.source === InventoryArmorSource.Inventory && isEqualItem(item, rhs)
+    );
+
+    // If this item is a collection/vendor item, ignore it if the player
+    // already has a real copy of the same item.
+    return purchasedItemInstance === undefined;
+  });
 
   let helmets = items
     .filter((i) => i.slot == ArmorSlot.ArmorSlotHelmet)

--- a/src/app/services/results-builder.worker.ts
+++ b/src/app/services/results-builder.worker.ts
@@ -204,10 +204,17 @@ addEventListener("message", async ({ data }) => {
     .filter((item) => item.slot != ArmorSlot.ArmorSlotNone)
     // filter disabled items
     .filter((item) => config.disabledItems.indexOf(item.itemInstanceId) == -1)
-    // filter collection rolls if not allowed
-    .filter(
-      (item) => config.includeCollectionRolls || item.source !== InventoryArmorSource.Collections
-    )
+    // filter collection/vendor rolls if not allowed
+    .filter((item) => {
+      switch (item.source) {
+        case InventoryArmorSource.Collections:
+          return config.includeCollectionRolls;
+        case InventoryArmorSource.Vendor:
+          return config.includeVendorRolls;
+        default:
+          return true;
+      }
+    })
     // filter the selected exotic right here
     .filter((item) => config.selectedExotics.indexOf(FORCE_USE_NO_EXOTIC) == -1 || !item.isExotic)
     .filter(

--- a/src/app/services/userdata.service.ts
+++ b/src/app/services/userdata.service.ts
@@ -17,9 +17,9 @@
 
 import { Injectable } from "@angular/core";
 import { AuthService } from "./auth.service";
-import { BungieApiService } from "./bungie-api.service";
 import { InventoryService } from "./inventory.service";
 import { DestinyClass } from "bungie-api-ts/destiny2/interfaces";
+import { MembershipService } from "./membership.service";
 
 @Injectable({
   providedIn: "root",
@@ -31,7 +31,7 @@ export class UserdataService {
 
   constructor(
     private auth: AuthService,
-    private api: BungieApiService,
+    private membership: MembershipService,
     private inventory: InventoryService
   ) {
     this.loadCachedData();
@@ -54,7 +54,7 @@ export class UserdataService {
   }
 
   private async updateCharacterData() {
-    this.characters = await this.api.getCharacters();
+    this.characters = await this.membership.getCharacters();
     localStorage.setItem("cachedCharacters", JSON.stringify(this.characters));
   }
 }

--- a/src/app/services/vendors.service.ts
+++ b/src/app/services/vendors.service.ts
@@ -1,0 +1,110 @@
+import { Injectable } from "@angular/core";
+import { environment } from "../../environments/environment";
+import {
+  getVendors,
+  HttpClientConfig,
+  DestinyComponentType,
+  DestinyItemType,
+} from "bungie-api-ts/destiny2";
+import { MembershipService } from "./membership.service";
+import { GroupUserInfoCard } from "bungie-api-ts/groupv2";
+import { IManifestArmor } from "../data/types/IManifestArmor";
+import {
+  IInventoryArmor,
+  InventoryArmorSource,
+  createArmorItem,
+  applyInvestmentStats,
+} from "../data/types/IInventoryArmor";
+import { HttpClientService } from "./http-client.service";
+import { DatabaseService } from "./database.service";
+
+@Injectable({
+  providedIn: "root",
+})
+export class VendorsService {
+  constructor(
+    private membership: MembershipService,
+    private http: HttpClientService,
+    private db: DatabaseService
+  ) {}
+
+  private async getVendorArmorItemsForCharacter(
+    manifestItems: Record<number, IManifestArmor>,
+    destinyMembership: GroupUserInfoCard,
+    characterId: string
+  ): Promise<IInventoryArmor[]> {
+    const vendorsResponse = await getVendors((d) => this.http.$http(d), {
+      components: [
+        DestinyComponentType.Vendors,
+        DestinyComponentType.VendorSales,
+        DestinyComponentType.ItemStats,
+      ],
+      characterId,
+      membershipType: destinyMembership.membershipType,
+      destinyMembershipId: destinyMembership.membershipId,
+      filter: 0,
+    });
+
+    const vendorArmorItems = Object.entries(vendorsResponse.Response.vendors.data ?? {})
+      .filter(([_vendorHash, vendor]) => vendor.enabled && vendor.canPurchase)
+      .flatMap(([vendorHash, vendor]) => {
+        const saleItems = vendorsResponse.Response.sales.data?.[vendorHash]?.saleItems ?? {};
+        const vendorItemStats =
+          vendorsResponse.Response.itemComponents[parseInt(vendorHash)].stats.data ?? {};
+
+        return Object.entries(saleItems)
+          .map(([vendorItemIndex, saleItem]) => {
+            const manifestItem = manifestItems[saleItem.itemHash];
+            const itemStats = vendorItemStats[parseInt(vendorItemIndex)];
+
+            if (!manifestItem || !itemStats) {
+              return;
+            }
+
+            const statsOverride = Object.values(itemStats.stats).reduce(
+              (acc, { statHash, value }) => {
+                acc[statHash] = value;
+                return acc;
+              },
+              {} as Record<number, number>
+            );
+
+            const r = createArmorItem(
+              manifestItem,
+              `v${vendorHash}-${saleItem.itemHash}`,
+              InventoryArmorSource.Vendor
+            );
+            applyInvestmentStats(r, statsOverride);
+            return r;
+          })
+          .filter(Boolean) as IInventoryArmor[];
+      });
+
+    console.log(
+      `Collected ${vendorArmorItems.length} vendor armor items for character ${characterId}`
+    );
+
+    return vendorArmorItems;
+  }
+
+  async getVendorArmorItems(): Promise<IInventoryArmor[]> {
+    const destinyMembership = await this.membership.getMembershipDataForCurrentUser();
+    const characters = await this.membership.getCharacters();
+
+    // This should contain a list of hashes for only the armor items which we are interested in
+    const manifestItems = (await this.db.manifestArmor.toArray())
+      .filter((a) => a.itemType == DestinyItemType.Armor)
+      .reduce((acc, item) => {
+        acc[item.hash] = item;
+        return acc;
+      }, {} as Record<number, IManifestArmor>);
+
+    const vendorArmorItems = await Promise.all(
+      characters.map(({ characterId }) =>
+        this.getVendorArmorItemsForCharacter(manifestItems, destinyMembership, characterId)
+      )
+    );
+
+    return vendorArmorItems.flat();
+  }
+}


### PR DESCRIPTION
Support the inclusion of collection and vendor items in searches

There is some work left to do:

- [x] Add option to enable/disable vendor items
- [ ] Cache vendor data until next reset
- [ ] Improve display of non-inventory items in lists
- [ ] Display vendor name in tooltips
- [X] ~~Currently the collection rolls feature only looks at exotics, this could be extended to include anything which can be pulled from collections if desirable (Blue armor items, Masks)~~ this would increase calculation costs too much for too little benefit
