### PR TITLE
Add Crota's End modslots to Armour Limitations

### DIFF
--- a/src/app/components/authenticated-v2/settings/desired-mod-limit-selection/desired-mod-limit-selection.component.html
+++ b/src/app/components/authenticated-v2/settings/desired-mod-limit-selection/desired-mod-limit-selection.component.html
@@ -113,6 +113,10 @@
           </td>
           <td>Vault of Glass</td>
           <td>
+            <app-armor-perk-icon [perk]="ArmorPerkOrSlot.SlotCrotasEnd"></app-armor-perk-icon>
+          </td>
+          <td>Crota's End</td>
+          <td>
             <app-armor-perk-icon [perk]="ArmorPerkOrSlot.SlotDeepStoneCrypt"></app-armor-perk-icon>
           </td>
           <td>Deep Stone Crypt</td>

--- a/src/app/components/authenticated-v2/settings/desired-mod-limit-selection/slot-limitation-selection/slot-limitation-selection.component.ts
+++ b/src/app/components/authenticated-v2/settings/desired-mod-limit-selection/slot-limitation-selection/slot-limitation-selection.component.ts
@@ -67,6 +67,7 @@ export class SlotLimitationSelectionComponent implements OnInit, OnDestroy, Afte
     ArmorPerkOrSlot.None,
     ArmorPerkOrSlot.PerkQueensFavor,
     ArmorPerkOrSlot.SonarAmplifier,
+    ArmorPerkOrSlot.SlotCrotasEnd,
     ArmorPerkOrSlot.SlotRootOfNightmares,
     ArmorPerkOrSlot.SlotKingsFall,
     ArmorPerkOrSlot.SlotVowOfTheDisciple,

--- a/src/app/data/enum/armor-stat.ts
+++ b/src/app/data/enum/armor-stat.ts
@@ -121,6 +121,7 @@ export enum ArmorPerkOrSlot {
   // A special case just for guardian games class items.
   GuardianGamesClassItem,
   SonarAmplifier,
+  SlotCrotasEnd,
   COUNT,
 }
 
@@ -142,6 +143,7 @@ export const ArmorPerkOrSlotNames: EnumDictionary<ArmorPerkOrSlot, string> = {
   [ArmorPerkOrSlot.SlotRootOfNightmares]: "Root of Nightmares Modslot",
   [ArmorPerkOrSlot.PerkQueensFavor]: "Queen's Favor",
   [ArmorPerkOrSlot.SonarAmplifier]: "Sonar Amplifier",
+  [ArmorPerkOrSlot.SlotCrotasEnd]: "Crota's End Modslot",
   [ArmorPerkOrSlot.COUNT]: "",
 };
 export const ArmorPerkOrSlotIcons: EnumDictionary<ArmorPerkOrSlot, string> = {
@@ -179,6 +181,8 @@ export const ArmorPerkOrSlotIcons: EnumDictionary<ArmorPerkOrSlot, string> = {
     "https://www.bungie.net/common/destiny2_content/icons/8d844c97fa13f4cb649358404d011be7.png",
   [ArmorPerkOrSlot.SonarAmplifier]:
     "https://www.bungie.net/common/destiny2_content/icons/e083d8a85c2c60825204d14b9e9263b7.png",
+  [ArmorPerkOrSlot.SlotCrotasEnd]:
+    "https://www.bungie.net/common/destiny2_content/icons/d89e12c918cb0c6b1087b073ad14d6c2.png",
   [ArmorPerkOrSlot.COUNT]: "",
 };
 
@@ -200,6 +204,7 @@ export const ArmorPerkOrSlotDIMText: EnumDictionary<ArmorPerkOrSlot, string> = {
   [ArmorPerkOrSlot.SlotRootOfNightmares]: "modslot:rootofnightmares",
   [ArmorPerkOrSlot.PerkQueensFavor]: 'perkname:"queen\'s favor"',
   [ArmorPerkOrSlot.SonarAmplifier]: 'perkname:"sonar amplifier"',
+  [ArmorPerkOrSlot.SlotCrotasEnd]: "modslot:crotasend",
   [ArmorPerkOrSlot.COUNT]: "",
 };
 

--- a/src/app/services/bungie-api.service.ts
+++ b/src/app/services/bungie-api.service.ts
@@ -505,6 +505,8 @@ export class BungieApiService {
       return ArmorPerkOrSlot.PerkPlunderersTrappings;
     if ((scks?.filter((d) => d.singleInitialItemHash == 3525583702) || []).length > 0)
       return ArmorPerkOrSlot.SeraphSensorArray;
+    if ((scks?.filter((d) => d.singleInitialItemHash == 717667840 ) || []).length > 0)
+      return ArmorPerkOrSlot.SlotCrotasEnd;
 
     return ArmorPerkOrSlot.None;
   }


### PR DESCRIPTION
Seems to work the same as the Root Of Nightmares one, is mostly a copy and paste.

Couldn't find an icon that was outlined the same as the other raid mod ones though.
