### PR TITLE
Fix ghost items

### DIFF
--- a/src/app/services/bungie-api.service.ts
+++ b/src/app/services/bungie-api.service.ts
@@ -385,8 +385,7 @@ export class BungieApiService {
 
     r = r.filter((k) => !k["statPlugHashes"] || k["statPlugHashes"][0] != null);
 
-    await this.db.inventoryArmor.where({ source: InventoryArmorSource.Inventory }).delete();
-    await this.db.inventoryArmor.where({ source: InventoryArmorSource.Collections }).delete();
+    await this.db.inventoryArmor.where("source").notEqual(InventoryArmorSource.Vendor).delete();
     await this.db.inventoryArmor.bulkAdd(r);
 
     localStorage.setItem("LastArmorUpdate", Date.now().toString());


### PR DESCRIPTION
fix: a possible fix for players reporting ghost items

The theory here would be that the reporting users are all users of an old version which was not tracking any source information,
    meaning the purge of old items wasn’t catching these due to having an empty source value (but was fixed permanently by re-logging).

We can just delete everything that’s not a Vendor source here instead, which may also be faster.