### PR TITLE
Only use masterworked exotic/legendary

### DIFF
--- a/src/app/components/authenticated-v2/results/results.component.html
+++ b/src/app/components/authenticated-v2/results/results.component.html
@@ -143,14 +143,25 @@
             &nbsp;Assume everything is artifice&nbsp;
             <mat-icon inline style="height: 100%">report_problem</mat-icon>
           </mat-chip>
+
           <mat-chip
             #tooltip="matTooltip"
-            *ngIf="_config_onlyUseMasterworkedItems"
+            *ngIf="_config_onlyUseMasterworkedExotics"
             disableRipple
-            matTooltip="This setting means that only armor pieces are used that are already masterworked."
+            matTooltip="This setting means that only exotic armor pieces that are already masterworked are used."
             selected>
-            Masterworked Only
+            Masterworked Exotics Only
           </mat-chip>
+
+          <mat-chip
+            #tooltip="matTooltip"
+            *ngIf="_config_onlyUseMasterworkedLegendaries"
+            disableRipple
+            matTooltip="This setting means that only legendary armor pieces are already masterworked are used."
+            selected>
+            Masterworked Legendaries Only
+          </mat-chip>
+
           <mat-chip
             #tooltip="matTooltip"
             *ngIf="

--- a/src/app/components/authenticated-v2/results/results.component.html
+++ b/src/app/components/authenticated-v2/results/results.component.html
@@ -165,7 +165,8 @@
           <mat-chip
             #tooltip="matTooltip"
             *ngIf="
-              !_config_onlyUseMasterworkedItems &&
+              !_config_onlyUseMasterworkedExotics &&
+              !_config_onlyUseMasterworkedLegendaries &&
               (_config_assumeLegendariesMasterworked ||
                 _config_assumeExoticsMasterworked ||
                 _config_assumeClassItemMasterworked)

--- a/src/app/components/authenticated-v2/results/results.component.ts
+++ b/src/app/components/authenticated-v2/results/results.component.ts
@@ -116,7 +116,8 @@ export class ResultsComponent implements OnInit, OnDestroy {
   _config_maximumStatMods: number = 5;
   _config_selectedExotics: number[] = [];
   _config_tryLimitWastedStats: boolean = false;
-  _config_onlyUseMasterworkedItems: Boolean = false;
+  _config_onlyUseMasterworkedExotics: Boolean = false;
+  _config_onlyUseMasterworkedLegendaries: Boolean = false;
   _config_includeCollectionRolls: Boolean = false;
   _config_includeVendorRolls: Boolean = false;
   _config_onlyShowResultsWithNoWastedStats: Boolean = false;
@@ -167,7 +168,8 @@ export class ResultsComponent implements OnInit, OnDestroy {
       this._config_limitParsedResults = c.limitParsedResults;
 
       this._config_maximumStatMods = c.maximumStatMods;
-      this._config_onlyUseMasterworkedItems = c.onlyUseMasterworkedItems;
+      this._config_onlyUseMasterworkedExotics = c.onlyUseMasterworkedExotics;
+      this._config_onlyUseMasterworkedLegendaries = c.onlyUseMasterworkedLegendaries;
       this._config_includeCollectionRolls = c.includeCollectionRolls;
       this._config_includeVendorRolls = c.includeVendorRolls;
       this._config_onlyShowResultsWithNoWastedStats = c.onlyShowResultsWithNoWastedStats;

--- a/src/app/components/authenticated-v2/settings/advanced-settings/advanced-settings.component.ts
+++ b/src/app/components/authenticated-v2/settings/advanced-settings/advanced-settings.component.ts
@@ -83,10 +83,19 @@ export class AdvancedSettingsComponent implements OnInit, OnDestroy {
             help: "If this setting is enabled, a plain +2 is added to every stat. This means that your Class Item must be masterworked.",
           },
           {
-            name: "Only use already masterworked items",
+            name: "Only use already masterworked exotic items",
             cp: (v: boolean) =>
-              this.config.modifyConfiguration((c) => (c.onlyUseMasterworkedItems = v)),
-            value: c.onlyUseMasterworkedItems,
+              this.config.modifyConfiguration((c) => (c.onlyUseMasterworkedExotics = v)),
+            value: c.onlyUseMasterworkedExotics,
+            disabled: false,
+            impactsResultCount: true,
+            help: undefined,
+          },
+          {
+            name: "Only use already masterworked legendary items",
+            cp: (v: boolean) =>
+              this.config.modifyConfiguration((c) => (c.onlyUseMasterworkedLegendaries = v)),
+            value: c.onlyUseMasterworkedLegendaries,
             disabled: false,
             impactsResultCount: true,
             help: undefined,

--- a/src/app/components/authenticated-v2/subpages/theorizer-page/theorizer-page.component.ts
+++ b/src/app/components/authenticated-v2/subpages/theorizer-page/theorizer-page.component.ts
@@ -580,8 +580,10 @@ export class TheorizerPageComponent implements OnInit {
     });
 
     // items = items
-    // config.onlyUseMasterworkedItems - only keep masterworked items
-    //.filter(item => !config.onlyUseMasterworkedItems || item.masterworked)
+    // config.OnlyUseMasterworkedExotics - only keep exotics that are masterworked
+    //.filter((item) => !config.onlyUseMasterworkedExotics || !(item.rarity == TierType.Exotic && !item.masterworked))
+    // config.OnlyUseMasterworkedLegendaries - only keep exotics that are masterworked
+    //.filter((item) => !config.onlyUseMasterworkedLegendaries || !(item.rarity == TierType.Superior && !item.masterworked))
     // non-legendaries and non-exotics
     //.filter(item => config.allowBlueArmorPieces || item.rarity == TierType.Exotic || item.rarity == TierType.Superior)
     // sunset armor

--- a/src/app/data/buildConfiguration.ts
+++ b/src/app/data/buildConfiguration.ts
@@ -84,7 +84,8 @@ export class BuildConfiguration {
   assumeLegendariesMasterworked = true;
   assumeExoticsMasterworked = true;
   assumeClassItemMasterworked = true;
-  onlyUseMasterworkedItems = false;
+  onlyUseMasterworkedExotics = false;
+  onlyUseMasterworkedLegendaries = false;
   modOptimizationStrategy: ModOptimizationStrategy = ModOptimizationStrategy.None;
   limitParsedResults = true; // Limits the amount of results that are parsed. This looses some results, but solves memory issues
   tryLimitWastedStats = false;
@@ -114,7 +115,8 @@ export class BuildConfiguration {
       putArtificeMods: true,
       useFotlArmor: false,
       maximumStatMods: MAXIMUM_STAT_MOD_AMOUNT,
-      onlyUseMasterworkedItems: false,
+      onlyUseMasterworkedExotics: false,
+      onlyUseMasterworkedLegendaries: false,
       ignoreSunsetArmor: false,
       includeCollectionRolls: false,
       includeVendorRolls: false,

--- a/src/app/services/results-builder.worker.ts
+++ b/src/app/services/results-builder.worker.ts
@@ -258,8 +258,21 @@ addEventListener("message", async ({ data }) => {
         selectedExotics[0].slot != item.slot ||
         selectedExotics[0].hash == item.hash
     )
-    // config.onlyUseMasterworkedItems - only keep masterworked items
-    .filter((item) => !config.onlyUseMasterworkedItems || item.masterworked)
+
+    // config.OnlyUseMasterworkedExotics - only keep exotics that are masterworked
+    .filter(
+      (item) =>
+        !config.onlyUseMasterworkedExotics ||
+        !(item.rarity == TierType.Exotic && !item.masterworked)
+    )
+
+    // config.OnlyUseMasterworkedLegendaries - only keep legendaries that are masterworked
+    .filter(
+      (item) =>
+        !config.onlyUseMasterworkedLegendaries ||
+        !(item.rarity == TierType.Superior && !item.masterworked)
+    )
+
     // non-legendaries and non-exotics
     .filter(
       (item) =>
@@ -383,7 +396,7 @@ addEventListener("message", async ({ data }) => {
   )) {
     /**
      *  At this point we already have:
-     *  - Masterworked items, if they must be masterworked (config.onlyUseMasterworkedItems)
+     *  - Masterworked Exotic/Legendaries, if they must be masterworked (config.onlyUseMasterworkedExotics/config.onlyUseMasterworkedLegendaries)
      *  - disabled items were already removed (config.disabledItems)
      */
     const slotCheckResult = checkSlots(


### PR DESCRIPTION
Splits the "Only use masterworked item" setting to specifically select masterworked exotics/legendaries to allow for more user customization.

If a user didn't have any masterworked exotics due to cost, they wouldn't be able to make any builds using the previous setting, as it considers all items. But now they can choose between rarities.